### PR TITLE
feat: add v0.2.0 schema with bar/verse hierarchy

### DIFF
--- a/schema/v0.2.0/wordgrain.schema.json
+++ b/schema/v0.2.0/wordgrain.schema.json
@@ -1,0 +1,387 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "title": "WordGrain",
+  "description": "A JSON format for storing vocabulary and lyrical structure data extracted from musical lyrics. Supports word (morpheme), bar (phrase/line), and verse (full verse) granularity levels.",
+  "type": "object",
+  "required": ["$schema", "schema_version", "type"],
+  "discriminator": {
+    "propertyName": "type"
+  },
+  "oneOf": [
+    { "$ref": "#/$defs/WordDocument" },
+    { "$ref": "#/$defs/BarDocument" },
+    { "$ref": "#/$defs/VerseDocument" }
+  ],
+  "$defs": {
+    "WordDocument": {
+      "type": "object",
+      "description": "Word-level (morpheme) grain document. Compatible with v0.1.0 structure.",
+      "required": ["$schema", "schema_version", "type", "meta", "grains"],
+      "additionalProperties": false,
+      "properties": {
+        "$schema": { "$ref": "#/$defs/SchemaUri" },
+        "schema_version": { "$ref": "#/$defs/SchemaVersion" },
+        "type": {
+          "const": "word"
+        },
+        "meta": { "$ref": "#/$defs/Meta" },
+        "grains": {
+          "type": "array",
+          "description": "Array of vocabulary grain entries",
+          "items": { "$ref": "#/$defs/Grain" },
+          "minItems": 0
+        }
+      }
+    },
+    "BarDocument": {
+      "type": "object",
+      "description": "Bar-level (phrase/line) grain document. Represents 1-2 lines of lyrics as a unit.",
+      "required": ["$schema", "schema_version", "type", "text", "source"],
+      "additionalProperties": false,
+      "properties": {
+        "$schema": { "$ref": "#/$defs/SchemaUri" },
+        "schema_version": { "$ref": "#/$defs/SchemaVersion" },
+        "type": {
+          "const": "bar"
+        },
+        "text": {
+          "type": "string",
+          "description": "The lyric text of the bar (1-2 lines)",
+          "minLength": 1
+        },
+        "source": { "$ref": "#/$defs/BarSource" },
+        "metrics": { "$ref": "#/$defs/BarMetrics" },
+        "semantics": { "$ref": "#/$defs/BarSemantics" },
+        "language": {
+          "type": "string",
+          "description": "ISO 639-1 language code",
+          "pattern": "^[a-z]{2}$",
+          "default": "en"
+        }
+      }
+    },
+    "VerseDocument": {
+      "type": "object",
+      "description": "Verse-level grain document. Represents a full verse. Detailed schema to be defined in a future version.",
+      "required": ["$schema", "schema_version", "type"],
+      "additionalProperties": true,
+      "properties": {
+        "$schema": { "$ref": "#/$defs/SchemaUri" },
+        "schema_version": { "$ref": "#/$defs/SchemaVersion" },
+        "type": {
+          "const": "verse"
+        }
+      }
+    },
+    "SchemaUri": {
+      "type": "string",
+      "format": "uri",
+      "description": "URI reference to the WordGrain schema version",
+      "pattern": "^https://raw\\.githubusercontent\\.com/shimpeiws/word-grain/main/schema/v[0-9]+\\.[0-9]+\\.[0-9]+/wordgrain\\.schema\\.json$"
+    },
+    "SchemaVersion": {
+      "type": "string",
+      "description": "Schema version identifier",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+      "examples": ["0.2.0"]
+    },
+    "BarSource": {
+      "type": "object",
+      "description": "Source information for a bar",
+      "required": ["artist", "track"],
+      "additionalProperties": false,
+      "properties": {
+        "artist": {
+          "type": "string",
+          "description": "Artist name",
+          "minLength": 1
+        },
+        "track": {
+          "type": "string",
+          "description": "Track/song title",
+          "minLength": 1
+        },
+        "album": {
+          "type": "string",
+          "description": "Album name"
+        },
+        "year": {
+          "type": "integer",
+          "description": "Release year",
+          "minimum": 1,
+          "maximum": 2200
+        },
+        "featuring": {
+          "type": "array",
+          "description": "Featured artists on this track",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "BarMetrics": {
+      "type": "object",
+      "description": "Quantitative metrics for a bar",
+      "additionalProperties": false,
+      "properties": {
+        "lines": {
+          "type": "integer",
+          "description": "Number of lines in the bar",
+          "minimum": 1
+        },
+        "syllables": {
+          "type": "integer",
+          "description": "Total syllable count",
+          "minimum": 0
+        },
+        "mora": {
+          "type": ["integer", "null"],
+          "description": "Mora count (for Japanese and other mora-timed languages). Null if not applicable.",
+          "minimum": 0
+        }
+      }
+    },
+    "BarSemantics": {
+      "type": "object",
+      "description": "Semantic attributes of a bar",
+      "additionalProperties": false,
+      "properties": {
+        "mood": {
+          "$ref": "#/$defs/Mood"
+        }
+      }
+    },
+    "Mood": {
+      "type": "string",
+      "description": "The dominant mood or emotional tone of the bar",
+      "enum": [
+        "cold",
+        "defiant",
+        "melancholic",
+        "aggressive",
+        "introspective",
+        "celebratory",
+        "tender",
+        "weary"
+      ]
+    },
+    "Meta": {
+      "type": "object",
+      "description": "Metadata about the WordGrain document",
+      "required": ["source", "artist", "generated_at"],
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "type": "string",
+          "description": "Data source identifier (e.g., 'genius', 'azlyrics', 'manual')",
+          "minLength": 1,
+          "examples": ["genius", "azlyrics", "spotify", "manual"]
+        },
+        "artist": {
+          "type": "string",
+          "description": "Primary artist name",
+          "minLength": 1
+        },
+        "artists": {
+          "type": "array",
+          "description": "Additional artists for collaborative corpora",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1
+        },
+        "corpus_size": {
+          "type": "integer",
+          "description": "Number of tracks analyzed",
+          "minimum": 0
+        },
+        "total_words": {
+          "type": "integer",
+          "description": "Total word count in analyzed corpus",
+          "minimum": 0
+        },
+        "generated_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp of document generation"
+        },
+        "generator": {
+          "type": "string",
+          "description": "Tool or pipeline that generated this document",
+          "examples": ["wordgrain-cli/1.0.0", "manual"]
+        },
+        "language": {
+          "type": "string",
+          "description": "ISO 639-1 language code",
+          "pattern": "^[a-z]{2}$",
+          "default": "en"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of this corpus"
+        }
+      }
+    },
+    "Grain": {
+      "type": "object",
+      "description": "A single vocabulary entry with linguistic and statistical data",
+      "required": ["word"],
+      "additionalProperties": false,
+      "properties": {
+        "word": {
+          "type": "string",
+          "description": "The vocabulary word or phrase",
+          "minLength": 1
+        },
+        "normalized": {
+          "type": "string",
+          "description": "Normalized/lemmatized form of the word",
+          "minLength": 1
+        },
+        "pos": {
+          "type": "string",
+          "description": "Part of speech tag",
+          "enum": [
+            "noun", "verb", "adjective", "adverb", "pronoun",
+            "preposition", "conjunction", "interjection",
+            "determiner", "particle", "other"
+          ]
+        },
+        "frequency": {
+          "type": "integer",
+          "description": "Raw occurrence count in corpus",
+          "minimum": 1
+        },
+        "frequency_normalized": {
+          "type": "number",
+          "description": "Frequency per 10,000 words",
+          "minimum": 0
+        },
+        "tfidf": {
+          "type": "number",
+          "description": "TF-IDF score (0.0 to 1.0)",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "sentiment": {
+          "type": "string",
+          "description": "Sentiment classification",
+          "enum": ["positive", "negative", "neutral", "mixed"]
+        },
+        "sentiment_score": {
+          "type": "number",
+          "description": "Sentiment score (-1.0 to 1.0)",
+          "minimum": -1,
+          "maximum": 1
+        },
+        "categories": {
+          "type": "array",
+          "description": "Semantic categories or tags",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "is_slang": {
+          "type": "boolean",
+          "description": "Whether the word is slang or non-standard"
+        },
+        "etymology": {
+          "type": "string",
+          "description": "Origin or etymology notes"
+        },
+        "definition": {
+          "type": "string",
+          "description": "Contextual definition within hip-hop culture"
+        },
+        "contexts": {
+          "type": "array",
+          "description": "Example usages from the corpus",
+          "items": { "$ref": "#/$defs/Context" },
+          "minItems": 1
+        },
+        "first_seen": {
+          "type": "string",
+          "description": "Earliest known usage (track or album)",
+          "minLength": 1
+        },
+        "collocations": {
+          "type": "array",
+          "description": "Frequently co-occurring words",
+          "items": { "$ref": "#/$defs/Collocation" }
+        },
+        "extensions": {
+          "type": "object",
+          "description": "Vendor-specific or experimental fields",
+          "additionalProperties": true
+        }
+      }
+    },
+    "Context": {
+      "type": "object",
+      "description": "A usage context from the lyrics corpus",
+      "required": ["line"],
+      "additionalProperties": false,
+      "properties": {
+        "line": {
+          "type": "string",
+          "description": "The lyric line containing the word",
+          "minLength": 1
+        },
+        "track": {
+          "type": "string",
+          "description": "Track/song title"
+        },
+        "album": {
+          "type": "string",
+          "description": "Album name"
+        },
+        "year": {
+          "type": "integer",
+          "description": "Release year",
+          "minimum": 1,
+          "maximum": 2200
+        },
+        "featuring": {
+          "type": "array",
+          "description": "Featured artists on this track",
+          "items": { "type": "string" }
+        },
+        "timestamp": {
+          "type": "string",
+          "description": "Timestamp in track (MM:SS format)",
+          "pattern": "^[0-9]{1,2}:[0-9]{2}$"
+        }
+      }
+    },
+    "Collocation": {
+      "type": "object",
+      "description": "A word that frequently appears with the grain word",
+      "required": ["word", "score"],
+      "additionalProperties": false,
+      "properties": {
+        "word": {
+          "type": "string",
+          "description": "The co-occurring word",
+          "minLength": 1
+        },
+        "score": {
+          "type": "number",
+          "description": "Collocation strength score (0.0 to 1.0)",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "position": {
+          "type": "string",
+          "description": "Typical position relative to grain word",
+          "enum": ["before", "after", "either"]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `schema/v0.2.0/wordgrain.schema.json` with discriminated union supporting `word`, `bar`, and `verse` types
- `word` type maintains full v0.1.0 compatibility
- `bar` type introduces phrase-level structure with `text`, `source`, `metrics` (lines/syllables/mora), and `semantics` (mood enum with 8 values)
- `verse` type is a placeholder for future expansion
- Add `schema_version` field to all document types

Closes #2