### PR TITLE
feat: update WG-RFC-001 spec to v0.2.0

### DIFF
--- a/spec/WG-RFC-001.md
+++ b/spec/WG-RFC-001.md
@@ -1,4 +1,4 @@
-# WG-RFC-001: WordGrain Specification v0.1.0
+# WG-RFC-001: WordGrain Specification v0.2.0
 
 | Field | Value |
 |-------|-------|
@@ -12,7 +12,7 @@
 
 ## Abstract
 
-WordGrain is a standardized JSON format for representing vocabulary data extracted from musical lyrics and other text sources. This specification defines the structure, fields, and validation rules for WordGrain documents.
+WordGrain is a standardized JSON format for representing vocabulary and lyrical structure data extracted from musical lyrics and other text sources. This specification defines the structure, fields, and validation rules for WordGrain documents at three granularity levels: word (morpheme), bar (phrase/line), and verse (full verse).
 
 ---
 
@@ -21,14 +21,16 @@ WordGrain is a standardized JSON format for representing vocabulary data extract
 1. [Motivation](#1-motivation)
 2. [Terminology](#2-terminology)
 3. [Specification](#3-specification)
-4. [File Conventions](#4-file-conventions)
-5. [Versioning](#5-versioning)
-6. [MIME Type](#6-mime-type)
-7. [Examples](#7-examples)
-8. [Validation](#8-validation)
-9. [Security Considerations](#9-security-considerations)
-10. [Future Extensions](#10-future-extensions)
-11. [References](#11-references)
+4. [Type Hierarchy](#4-type-hierarchy)
+5. [File Conventions](#5-file-conventions)
+6. [Versioning](#6-versioning)
+7. [MIME Type](#7-mime-type)
+8. [Examples](#8-examples)
+9. [Validation](#9-validation)
+10. [Security Considerations](#10-security-considerations)
+11. [Design Decisions](#11-design-decisions)
+12. [Future Extensions](#12-future-extensions)
+13. [References](#13-references)
 
 ---
 
@@ -66,9 +68,12 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 | Term | Definition |
 |------|------------|
 | Grain | A single vocabulary entry with associated metadata |
+| Bar | A phrase or 1-2 line unit of lyrics, named after the musical term for a measure |
+| Verse | A full verse section of a song |
 | Corpus | The collection of lyrics analyzed to produce grains |
 | Context | A specific usage instance of a word in lyrics |
 | TF-IDF | Term Frequency-Inverse Document Frequency score |
+| Mood | The dominant emotional tone of a bar |
 
 ---
 
@@ -76,11 +81,23 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### 3.1 Document Structure
 
-A WordGrain document is a JSON object with three top-level properties:
+A WordGrain document is a JSON object whose structure is determined by the `type` field. All document types share these common top-level properties:
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `$schema` | string (URI) | REQUIRED | Schema version URI |
+| `schema_version` | string | REQUIRED | Semver version string (e.g., `"0.2.0"`) |
+| `type` | string | REQUIRED | Document type: `"word"`, `"bar"`, or `"verse"` |
+
+The remaining properties depend on the `type` value. See [Section 4: Type Hierarchy](#4-type-hierarchy) for details.
+
+#### 3.1.1 Word Document (v0.1.0 compatible)
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json",
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
+  "type": "word",
   "meta": { ... },
   "grains": [ ... ]
 }
@@ -88,7 +105,6 @@ A WordGrain document is a JSON object with three top-level properties:
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `$schema` | string (URI) | REQUIRED | Schema version URI |
 | `meta` | object | REQUIRED | Document metadata |
 | `grains` | array | REQUIRED | Array of grain objects |
 
@@ -198,9 +214,108 @@ Extension keys SHOULD be prefixed with `x-` to indicate non-standard fields.
 
 ---
 
-## 4. File Conventions
+## 4. Type Hierarchy
 
-### 4.1 File Extension
+### 4.1 Overview
+
+WordGrain v0.2.0 introduces a three-level type hierarchy for representing lyrical data at different granularities:
+
+| Type | Granularity | Description |
+|------|-------------|-------------|
+| `word` | Morpheme/token | Individual vocabulary entries with linguistic metadata. Compatible with v0.1.0. |
+| `bar` | Phrase/line (1-2 lines) | A short lyrical unit, typically a measure in musical terms. |
+| `verse` | Full verse | A complete verse section. Reserved for future specification. |
+
+The `type` field acts as a discriminator: each type has its own set of required and optional properties.
+
+### 4.2 Bar Type
+
+A `bar` document represents a phrase-level lyrical unit (1-2 lines). This is the primary new type in v0.2.0.
+
+#### 4.2.1 Bar Document Structure
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
+  "type": "bar",
+  "text": "俺はまだ関係ねえ 関係ねえ 関係ねえ",
+  "source": {
+    "artist": "KOHH",
+    "track": "貧乏なんて気にしない",
+    "album": "YELLOW T△PE 3",
+    "year": 2016
+  },
+  "metrics": {
+    "lines": 1,
+    "syllables": 18,
+    "mora": 20
+  },
+  "semantics": {
+    "mood": "defiant"
+  },
+  "language": "ja"
+}
+```
+
+#### 4.2.2 Bar Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `text` | string | REQUIRED | The lyric text of the bar (1-2 lines) |
+| `source` | object | REQUIRED | Source attribution (see 4.2.3) |
+| `metrics` | object | OPTIONAL | Quantitative metrics (see 4.2.4) |
+| `semantics` | object | OPTIONAL | Semantic attributes (see 4.2.5) |
+| `language` | string | OPTIONAL | ISO 639-1 language code (default: `"en"`) |
+
+#### 4.2.3 Source Object
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `artist` | string | REQUIRED | Artist name |
+| `track` | string | REQUIRED | Track/song title |
+| `album` | string | OPTIONAL | Album name |
+| `year` | integer | OPTIONAL | Release year (1-2200) |
+| `featuring` | string[] | OPTIONAL | Featured artists |
+
+#### 4.2.4 Metrics Object
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `lines` | integer | Number of lines in the bar (>= 1) |
+| `syllables` | integer | Total syllable count (>= 0) |
+| `mora` | integer or null | Mora count for mora-timed languages (e.g., Japanese). Null if not applicable. |
+
+#### 4.2.5 Semantics Object
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `mood` | string | The dominant mood/emotional tone (see 4.2.6) |
+
+#### 4.2.6 Mood Enum
+
+The `mood` field captures the dominant emotional tone of a bar. It uses a curated set of 8 values chosen to represent the emotional spectrum commonly found in hip-hop and related genres:
+
+| Value | Description |
+|-------|-------------|
+| `cold` | Cool, detached, controlled menace |
+| `defiant` | Rebellious, resistant, confrontational |
+| `melancholic` | Sad, reflective, sorrowful |
+| `aggressive` | Hostile, intense, hard-hitting |
+| `introspective` | Self-examining, thoughtful, philosophical |
+| `celebratory` | Triumphant, joyful, boastful |
+| `tender` | Gentle, vulnerable, affectionate |
+| `weary` | Tired, worn, resigned |
+
+### 4.3 Verse Type
+
+The `verse` type is reserved for representing full verse sections. Its detailed schema will be defined in a future version. Currently, `verse` documents require only the common top-level fields (`$schema`, `schema_version`, `type`) and allow additional properties.
+
+---
+
+## 5. File Conventions
+
+### 5.1 File Extension
 
 WordGrain files SHOULD use the `.wg.json` extension:
 
@@ -209,7 +324,7 @@ kendrick-lamar.wg.json
 wu-tang-clan.wg.json
 ```
 
-### 4.2 Naming Conventions
+### 5.2 Naming Conventions
 
 | Pattern | Example | Use Case |
 |---------|---------|----------|
@@ -219,15 +334,15 @@ wu-tang-clan.wg.json
 
 Slugs SHOULD be lowercase, hyphen-separated ASCII.
 
-### 4.3 Encoding
+### 5.3 Encoding
 
 Files MUST be encoded as UTF-8 without BOM.
 
 ---
 
-## 5. Versioning
+## 6. Versioning
 
-### 5.1 Schema Version
+### 6.1 Schema Version
 
 The `$schema` field indicates the specification version:
 
@@ -235,7 +350,7 @@ The `$schema` field indicates the specification version:
 https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v{MAJOR}.{MINOR}.{PATCH}/wordgrain.schema.json
 ```
 
-### 5.2 Semantic Versioning Rules
+### 6.2 Semantic Versioning Rules
 
 | Change Type | Version Bump | Example |
 |-------------|--------------|---------|
@@ -243,14 +358,14 @@ https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v{MAJOR}.{MIN
 | New optional fields | MINOR | v0.1.0 -> v0.2.0 |
 | Documentation/typo fixes | PATCH | v0.1.0 -> v0.1.1 |
 
-### 5.3 Compatibility
+### 6.3 Compatibility
 
 - Consumers SHOULD ignore unknown fields for forward compatibility
 - Producers MUST NOT remove required fields in minor versions
 
 ---
 
-## 6. MIME Type
+## 7. MIME Type
 
 Recommended MIME type: `application/vnd.wordgrain+json`
 
@@ -258,13 +373,15 @@ Until registered, use: `application/json`
 
 ---
 
-## 7. Examples
+## 8. Examples
 
-### 7.1 Minimal Valid Document
+### 8.1 Minimal Valid Document (Word Type)
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json",
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
+  "type": "word",
   "meta": {
     "source": "manual",
     "artist": "Example Artist",
@@ -274,66 +391,119 @@ Until registered, use: `application/json`
 }
 ```
 
-### 7.2 Complete Example
+### 8.2 Bar Type Example
 
-See [examples/kendrick-lamar.wg.json](../examples/kendrick-lamar.wg.json) for a full-featured example.
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
+  "type": "bar",
+  "text": "俺はまだ関係ねえ 関係ねえ 関係ねえ",
+  "source": {
+    "artist": "KOHH",
+    "track": "貧乏なんて気にしない",
+    "album": "YELLOW T△PE 3",
+    "year": 2016
+  },
+  "metrics": {
+    "lines": 1,
+    "syllables": 18,
+    "mora": 20
+  },
+  "semantics": {
+    "mood": "defiant"
+  },
+  "language": "ja"
+}
+```
+
+### 8.3 Complete Word Example
+
+See [examples/kendrick-lamar.wg.json](../examples/kendrick-lamar.wg.json) for a full-featured word-type example.
 
 ---
 
-## 8. Validation
+## 9. Validation
 
-### 8.1 JSON Schema
+### 9.1 JSON Schema
 
 The official JSON Schema is available at:
 
-- Local: [schema/v0.1.0/wordgrain.schema.json](../schema/v0.1.0/wordgrain.schema.json)
-- Remote: `https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json`
+- Local: [schema/v0.2.0/wordgrain.schema.json](../schema/v0.2.0/wordgrain.schema.json)
+- Remote: `https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json`
 
-### 8.2 Validation Rules
+### 9.2 Validation Rules
 
 1. Document MUST be valid JSON
 2. Document MUST validate against the JSON Schema
 3. `generated_at` MUST be a valid ISO 8601 datetime
 4. `tfidf` and `sentiment_score` MUST be within specified ranges
 
-### 8.3 Validation Commands
+### 9.3 Validation Commands
 
 ```bash
 # Using ajv-cli
-npx ajv validate -s schema/v0.1.0/wordgrain.schema.json -d your-file.wg.json --spec=draft2020
+npx ajv validate -s schema/v0.2.0/wordgrain.schema.json -d your-file.wg.json --spec=draft2020
 
 # Using Python jsonschema
-python -m jsonschema -i your-file.wg.json schema/v0.1.0/wordgrain.schema.json
+python -m jsonschema -i your-file.wg.json schema/v0.2.0/wordgrain.schema.json
 ```
 
 ---
 
-## 9. Security Considerations
+## 10. Security Considerations
 
-### 9.1 Copyright
+### 10.1 Copyright
 
 - Context lines SHOULD be limited excerpts (fair use)
 - Full lyrics MUST NOT be stored
 - Attribution to original artists is RECOMMENDED
 
-### 9.2 Data Validation
+### 10.2 Data Validation
 
 - Consumers SHOULD validate input against schema
 - Untrusted sources SHOULD be sanitized
 
 ---
 
-## 10. Future Extensions
+## 11. Design Decisions
 
-### 10.1 Planned for v0.2.0
+This section records key design decisions made in v0.2.0 and their rationale.
+
+### 11.1 "bar" over "phrase"
+
+The term **bar** was chosen over "phrase" for the line-level type. In music, a "bar" (or measure) is a natural unit of rhythmic structure. Since WordGrain is designed for lyric analysis in hip-hop and related genres, the musical terminology is more intuitive and idiomatic for the target audience. "Phrase" is a more generic linguistic term that lacks this musical connotation.
+
+### 11.2 No `vector` / `embedding` field
+
+Embedding vectors were considered for v0.2.0 but ultimately excluded. Reasons:
+
+- **Size**: Embedding vectors (e.g., 384 or 768 dimensions) would dramatically increase file size, conflicting with the goal of human-readable, lightweight JSON files.
+- **Volatility**: Embedding models evolve rapidly; baking a specific model's output into the schema would create tight coupling.
+- **Scope**: Embeddings are better served by dedicated vector stores or the `extensions` field for experimental use.
+
+### 11.3 Simplified `semantics` (no `intensity`, no `tags`)
+
+Earlier drafts included `intensity` (a numeric scale) and `tags` (free-form string array) in the `semantics` object. These were removed:
+
+- **`intensity`**: Subjective and difficult to calibrate consistently across annotators. The `mood` enum alone provides sufficient signal.
+- **`tags`**: Too open-ended, leading to inconsistent and noisy data. Structured fields (like `mood`) are preferred for interoperability.
+
+The `semantics` object now contains only `mood`, keeping it focused and reliable.
+
+---
+
+## 12. Future Extensions
+
+### 12.1 Planned for v0.3.0+
 
 | Feature | Description |
 |---------|-------------|
-| `embedding` | Word embedding vectors |
+| `verse` type detail | Full schema for verse-level documents |
 | `phonetics` | IPA pronunciation, rhyme patterns |
 | `audio_link` | Reference to audio timestamps |
 
-### 10.2 Planned for v1.0.0
+### 12.2 Planned for v1.0.0
 
 | Feature | Description |
 |---------|-------------|
@@ -341,9 +511,9 @@ python -m jsonschema -i your-file.wg.json schema/v0.1.0/wordgrain.schema.json
 | Binary format | Efficient storage for embeddings |
 | Multi-language | Full i18n support |
 
-### 10.3 Extension Mechanism
+### 12.3 Extension Mechanism
 
-Custom fields can be added via the `extensions` object:
+Custom fields can be added via the `extensions` object in word-type documents:
 
 ```json
 {
@@ -357,7 +527,7 @@ Custom fields can be added via the `extensions` object:
 
 ---
 
-## 11. References
+## 13. References
 
 - [RFC 2119](https://tools.ietf.org/html/rfc2119) - Key words
 - [JSON Schema](https://json-schema.org/) - Validation
@@ -370,4 +540,5 @@ Custom fields can be added via the `extensions` object:
 
 | Version | Date | Changes |
 |---------|------|---------|
+| v0.2.0 | 2026-03-05 | Add type hierarchy (word/bar/verse), bar type with source/metrics/semantics, mood enum, schema_version field, design decisions section |
 | v0.1.0 | 2026-02-08 | Initial draft |


### PR DESCRIPTION
## Summary

- Update WG-RFC-001 specification from v0.1.0 to v0.2.0
- Add Section 4: Type Hierarchy with word/bar/verse definitions
- Define bar type fields (text, source, metrics, semantics, language)
- Define mood enum with 8 values
- Add Section 11: Design Decisions (bar naming rationale, no vector/embedding, simplified semantics)
- Update all schema references and examples to v0.2.0

Closes #3