### PR TITLE
feat: update README and examples for v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WordGrain Specification
 
-A JSON format for storing vocabulary data extracted from musical lyrics. Originally developed for hip-hop lyric analysis.
+A JSON format for storing vocabulary and lyrical structure data extracted from musical lyrics. Originally developed for hip-hop lyric analysis.
 
 ## Documentation
 
@@ -8,20 +8,23 @@ Full documentation is available at: https://shimpeiws.github.io/word-grain/
 
 ## Overview
 
-WordGrain provides a standardized way to represent linguistic analysis of musical lyrics, including:
+WordGrain provides a standardized way to represent linguistic analysis of musical lyrics at multiple granularity levels:
 
-- Vocabulary with frequency and TF-IDF scores
-- Part of speech and sentiment analysis
-- Contextual examples from actual lyrics
-- Collocation and usage patterns
+| Type | Granularity | Description |
+|------|-------------|-------------|
+| `word` | Morpheme/token | Vocabulary entries with frequency, TF-IDF, sentiment, and contextual data |
+| `bar` | Phrase/line | 1-2 line lyrical units with source, metrics, and mood |
+| `verse` | Full verse | Complete verse sections (coming soon) |
 
 ## Quick Start
 
-### Minimal Example
+### Word Type (v0.1.0 compatible)
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json",
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
+  "type": "word",
   "meta": {
     "source": "genius",
     "artist": "Kendrick Lamar",
@@ -37,14 +40,40 @@ WordGrain provides a standardized way to represent linguistic analysis of musica
 }
 ```
 
+### Bar Type (new in v0.2.0)
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
+  "type": "bar",
+  "text": "俺はまだ関係ねえ 関係ねえ 関係ねえ",
+  "source": {
+    "artist": "KOHH",
+    "track": "貧乏なんて気にしない",
+    "album": "YELLOW T△PE 3",
+    "year": 2016
+  },
+  "metrics": {
+    "lines": 1,
+    "syllables": 18,
+    "mora": 20
+  },
+  "semantics": {
+    "mood": "defiant"
+  },
+  "language": "ja"
+}
+```
+
 ### Validation
 
 ```bash
 # Using ajv-cli
-npx ajv validate -s schema/v0.1.0/wordgrain.schema.json -d your-file.wg.json
+npx ajv validate -s schema/v0.2.0/wordgrain.schema.json -d your-file.wg.json --spec=draft2020
 
 # Using Python jsonschema
-python -m jsonschema -i your-file.wg.json schema/v0.1.0/wordgrain.schema.json
+python -m jsonschema -i your-file.wg.json schema/v0.2.0/wordgrain.schema.json
 ```
 
 ## Specification
@@ -55,21 +84,22 @@ See [spec/WG-RFC-001.md](spec/WG-RFC-001.md) for the full specification.
 
 - Extension: `.wg.json`
 - Encoding: UTF-8
-- Naming: `{artist-slug}.wg.json`
+- Naming: `{artist-slug}.wg.json` (word type), `{artist-slug}-bar.wg.json` (bar type)
 
 ## Examples
 
-| File | Description |
-|------|-------------|
-| [examples/minimal.wg.json](examples/minimal.wg.json) | Minimal valid document |
-| [examples/kendrick-lamar.wg.json](examples/kendrick-lamar.wg.json) | Full-featured example |
+| File | Type | Description |
+|------|------|-------------|
+| [examples/minimal.wg.json](examples/minimal.wg.json) | word | Minimal valid document |
+| [examples/kendrick-lamar.wg.json](examples/kendrick-lamar.wg.json) | word | Full-featured word example |
+| [examples/kohh-bar.wg.json](examples/kohh-bar.wg.json) | bar | Bar type example (Japanese) |
 
 ## Schema
 
 The JSON Schema is available at:
 
-- Local: [schema/v0.1.0/wordgrain.schema.json](schema/v0.1.0/wordgrain.schema.json)
-- Remote: `https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json`
+- **v0.2.0** (latest): [schema/v0.2.0/wordgrain.schema.json](schema/v0.2.0/wordgrain.schema.json) / [Remote](https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json)
+- v0.1.0: [schema/v0.1.0/wordgrain.schema.json](schema/v0.1.0/wordgrain.schema.json) / [Remote](https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json)
 
 ## License
 

--- a/examples/kohh-bar.wg.json
+++ b/examples/kohh-bar.wg.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
+  "type": "bar",
+  "text": "俺はまだ関係ねえ 関係ねえ 関係ねえ",
+  "source": {
+    "artist": "KOHH",
+    "track": "貧乏なんて気にしない",
+    "album": "YELLOW T△PE 3",
+    "year": 2016
+  },
+  "metrics": {
+    "lines": 1,
+    "syllables": 18,
+    "mora": 20
+  },
+  "semantics": {
+    "mood": "defiant"
+  },
+  "language": "ja"
+}


### PR DESCRIPTION
## Summary

- Update README with v0.2.0 type hierarchy overview (word/bar/verse table)
- Add bar type quick start example alongside existing word example
- Add `examples/kohh-bar.wg.json` as a bar type sample file (KOHH, Japanese)
- Update validation commands and schema links to v0.2.0

Closes #4