### PR TITLE
feat: update documentation site for v0.2.0

### DIFF
--- a/site/app/explorer/page.tsx
+++ b/site/app/explorer/page.tsx
@@ -7,7 +7,7 @@ import SchemaViewer from "@/components/explorer/SchemaViewer";
 import WordCloudViz from "@/components/explorer/WordCloudViz";
 import FrequencyChart from "@/components/explorer/FrequencyChart";
 import GrainDataTable from "@/components/explorer/GrainDataTable";
-import type { WordGrainDocument } from "@/lib/types";
+import type { WordGrainDocument, WordDocument } from "@/lib/types";
 
 type Tab = "validator" | "schema" | "visualization";
 
@@ -88,27 +88,33 @@ export default function ExplorerPage() {
                   visualize the data.
                 </p>
               </div>
+            ) : !("grains" in validatedData) ? (
+              <div className="rounded-lg border border-dashed border-zinc-300 bg-zinc-50 p-12 text-center dark:border-zinc-600 dark:bg-zinc-800/50">
+                <p className="text-sm text-zinc-500">
+                  Visualization is currently available for <code className="rounded bg-zinc-100 px-1.5 py-0.5 font-mono text-xs dark:bg-zinc-700">word</code> type documents only.
+                </p>
+              </div>
             ) : (
               <>
                 <section>
                   <h2 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
                     Word Cloud
                   </h2>
-                  <WordCloudViz grains={validatedData.grains} />
+                  <WordCloudViz grains={(validatedData as WordDocument).grains} />
                 </section>
 
                 <section>
                   <h2 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
                     Top Words by Frequency
                   </h2>
-                  <FrequencyChart grains={validatedData.grains} />
+                  <FrequencyChart grains={(validatedData as WordDocument).grains} />
                 </section>
 
                 <section>
                   <h2 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
                     Grain Data
                   </h2>
-                  <GrainDataTable grains={validatedData.grains} />
+                  <GrainDataTable grains={(validatedData as WordDocument).grains} />
                 </section>
               </>
             )}

--- a/site/app/playground/page.tsx
+++ b/site/app/playground/page.tsx
@@ -7,7 +7,7 @@ import {
   validate,
   type ValidationResult,
 } from "@/lib/validation";
-import type { WordGrainDocument } from "@/lib/types";
+import type { WordGrainDocument, WordDocument } from "@/lib/types";
 
 export default function PlaygroundPage() {
   const [schema, setSchema] = useState<Record<string, unknown> | null>(null);
@@ -18,7 +18,7 @@ export default function PlaygroundPage() {
 
   // Fetch schema on mount
   useEffect(() => {
-    fetch("/word-grain/schema/v0.1.0/wordgrain.schema.json")
+    fetch(`${process.env.NEXT_PUBLIC_BASE_PATH ?? "/word-grain"}/schema/v0.2.0/wordgrain.schema.json`)
       .then((res) => {
         if (!res.ok) throw new Error("Failed to load schema");
         return res.json();
@@ -93,6 +93,10 @@ export default function PlaygroundPage() {
   }, [rightJson, rightResult]);
 
   const bothValid = leftDoc !== null && rightDoc !== null;
+  const bothWord =
+    bothValid &&
+    "grains" in leftDoc &&
+    "grains" in rightDoc;
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-10">
@@ -117,9 +121,9 @@ export default function PlaygroundPage() {
         />
       </section>
 
-      {bothValid && (
+      {bothWord && (
         <section className="mb-10">
-          <StatsSummary left={leftDoc} right={rightDoc} />
+          <StatsSummary left={leftDoc as WordDocument} right={rightDoc as WordDocument} />
         </section>
       )}
 

--- a/site/components/landing/HeroSection.tsx
+++ b/site/components/landing/HeroSection.tsx
@@ -1,6 +1,13 @@
+"use client";
+
+import { useState } from "react";
 import Link from "next/link";
 
+type SnippetTab = "word" | "bar";
+
 export default function HeroSection() {
+  const [snippet, setSnippet] = useState<SnippetTab>("bar");
+
   return (
     <section className="relative overflow-hidden border-b border-zinc-200 dark:border-zinc-800">
       {/* Gradient background */}
@@ -13,12 +20,13 @@ export default function HeroSection() {
             WordGrain
           </h1>
           <p className="mt-6 text-xl text-zinc-600 sm:text-2xl dark:text-zinc-400">
-            A JSON format for vocabulary data from musical lyrics
+            A JSON format for vocabulary and lyrical structure data from musical
+            lyrics
           </p>
           <p className="mt-4 max-w-2xl text-base text-zinc-500 dark:text-zinc-500">
             WordGrain defines a standardized schema for storing vocabulary data
             extracted from musical lyrics -- word frequencies, sentiment, usage
-            contexts, and more.
+            contexts, and phrase-level mood analysis.
           </p>
 
           <div className="mt-10 flex flex-wrap gap-4">
@@ -63,25 +71,90 @@ export default function HeroSection() {
           </div>
         </div>
 
-        {/* Decorative code snippet */}
+        {/* Decorative code snippet with tab toggle */}
         <div className="absolute right-8 top-1/2 hidden -translate-y-1/2 lg:block">
-          <div className="w-96 rounded-lg border border-zinc-200/60 bg-white/70 p-8 font-mono text-base text-zinc-400 shadow-sm backdrop-blur dark:border-zinc-700/60 dark:bg-zinc-900/70 dark:text-zinc-600">
-            <div className="text-zinc-500 dark:text-zinc-500">
-              {"{"} <span className="text-blue-600 dark:text-blue-400">&quot;word&quot;</span>: <span className="text-green-600 dark:text-green-400">&quot;hustle&quot;</span>,
+          <div className="w-96 rounded-lg border border-zinc-200/60 bg-white/70 shadow-sm backdrop-blur dark:border-zinc-700/60 dark:bg-zinc-900/70">
+            {/* Snippet tabs */}
+            <div className="flex border-b border-zinc-200/60 dark:border-zinc-700/60">
+              <button
+                type="button"
+                onClick={() => setSnippet("bar")}
+                className={`px-4 py-2 text-xs font-medium transition-colors ${
+                  snippet === "bar"
+                    ? "border-b-2 border-blue-500 text-blue-600 dark:text-blue-400"
+                    : "text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300"
+                }`}
+              >
+                bar
+              </button>
+              <button
+                type="button"
+                onClick={() => setSnippet("word")}
+                className={`px-4 py-2 text-xs font-medium transition-colors ${
+                  snippet === "word"
+                    ? "border-b-2 border-blue-500 text-blue-600 dark:text-blue-400"
+                    : "text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300"
+                }`}
+              >
+                word
+              </button>
             </div>
-            <div className="ml-6 text-zinc-500 dark:text-zinc-500">
-              <span className="text-blue-600 dark:text-blue-400">&quot;frequency&quot;</span>: <span className="text-amber-600 dark:text-amber-400">47</span>,
+
+            <div className="p-8 font-mono text-base text-zinc-400 dark:text-zinc-600">
+              {snippet === "bar" ? <BarSnippet /> : <WordSnippet />}
             </div>
-            <div className="ml-6 text-zinc-500 dark:text-zinc-500">
-              <span className="text-blue-600 dark:text-blue-400">&quot;sentiment&quot;</span>: <span className="text-green-600 dark:text-green-400">&quot;positive&quot;</span>,
-            </div>
-            <div className="ml-6 text-zinc-500 dark:text-zinc-500">
-              <span className="text-blue-600 dark:text-blue-400">&quot;tfidf&quot;</span>: <span className="text-amber-600 dark:text-amber-400">0.82</span>
-            </div>
-            <div className="text-zinc-500 dark:text-zinc-500">{"}"}</div>
           </div>
         </div>
       </div>
     </section>
   );
+}
+
+function BarSnippet() {
+  return (
+    <>
+      <Line>{"{"} <K>type</K>: <S>bar</S>,</Line>
+      <Line indent={1}><K>text</K>: <S>俺はまだ関係ねえ...</S>,</Line>
+      <Line indent={1}><K>source</K>: {"{"}</Line>
+      <Line indent={2}><K>artist</K>: <S>KOHH</S>,</Line>
+      <Line indent={2}><K>track</K>: <S>貧乏なんて気にしない</S></Line>
+      <Line indent={1}>{"}"},</Line>
+      <Line indent={1}><K>semantics</K>: {"{"}</Line>
+      <Line indent={2}><K>mood</K>: <S>defiant</S></Line>
+      <Line indent={1}>{"}"}</Line>
+      <Line>{"}"}</Line>
+    </>
+  );
+}
+
+function WordSnippet() {
+  return (
+    <>
+      <Line>{"{"} <K>word</K>: <S>hustle</S>,</Line>
+      <Line indent={1}><K>frequency</K>: <N>47</N>,</Line>
+      <Line indent={1}><K>sentiment</K>: <S>positive</S>,</Line>
+      <Line indent={1}><K>tfidf</K>: <N>0.82</N></Line>
+      <Line>{"}"}</Line>
+    </>
+  );
+}
+
+function Line({ children, indent = 0 }: { children: React.ReactNode; indent?: number }) {
+  return (
+    <div className={`text-zinc-500 dark:text-zinc-500`} style={{ marginLeft: indent * 24 }}>
+      {children}
+    </div>
+  );
+}
+
+function K({ children }: { children: React.ReactNode }) {
+  return <span className="text-blue-600 dark:text-blue-400">&quot;{children}&quot;</span>;
+}
+
+function S({ children }: { children: React.ReactNode }) {
+  return <span className="text-green-600 dark:text-green-400">&quot;{children}&quot;</span>;
+}
+
+function N({ children }: { children: React.ReactNode }) {
+  return <span className="text-amber-600 dark:text-amber-400">{children}</span>;
 }

--- a/site/components/landing/SchemaOverview.tsx
+++ b/site/components/landing/SchemaOverview.tsx
@@ -1,7 +1,21 @@
+"use client";
+
+import { useState } from "react";
+
 const MAIN_COL = 300;
 const SUB_COL = 200;
 
+type TabKey = "word" | "bar" | "verse";
+
+const TABS: { key: TabKey; label: string }[] = [
+  { key: "word", label: "word" },
+  { key: "bar", label: "bar" },
+  { key: "verse", label: "verse" },
+];
+
 export default function SchemaOverview() {
+  const [activeTab, setActiveTab] = useState<TabKey>("word");
+
   return (
     <section className="mx-auto max-w-6xl px-4 py-16 sm:py-24">
       <div className="text-center">
@@ -9,170 +23,42 @@ export default function SchemaOverview() {
           Document Structure
         </h2>
         <p className="mt-3 text-base text-zinc-500 dark:text-zinc-400">
-          A WordGrain document is a JSON file with a simple, well-defined
-          hierarchy.
+          WordGrain supports three granularity levels. Each document declares its{" "}
+          <code className="rounded bg-zinc-100 px-1.5 py-0.5 text-sm font-mono dark:bg-zinc-800">
+            type
+          </code>{" "}
+          to determine its structure.
         </p>
       </div>
 
-      {/* Desktop Tree */}
-      <div className="mt-12 hidden justify-center overflow-x-auto sm:flex">
-        <div className="flex flex-col items-center">
-          <TreeNode
-            label="Document"
-            type="object"
-            accent
-            fields={["$schema", "meta", "grains[]"]}
-          />
-
-          <TreeConnector cols={2} colWidth={MAIN_COL} />
-
-          <div className="flex" style={{ width: MAIN_COL * 2 }}>
-            {/* meta column */}
-            <div
-              style={{ width: MAIN_COL }}
-              className="flex flex-col items-center"
+      {/* Type tabs */}
+      <div className="mt-8 flex justify-center">
+        <div className="inline-flex rounded-lg border border-zinc-200 bg-zinc-50 p-1 dark:border-zinc-700 dark:bg-zinc-800/50">
+          {TABS.map((tab) => (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => setActiveTab(tab.key)}
+              className={`rounded-md px-4 py-2 text-sm font-medium transition-colors ${
+                activeTab === tab.key
+                  ? "bg-white text-zinc-900 shadow-sm dark:bg-zinc-700 dark:text-zinc-100"
+                  : "text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300"
+              }`}
             >
-              <TreeNode
-                label="meta"
-                type="object"
-                fields={[
-                  "source: string",
-                  "artist: string",
-                  "corpus_size: integer",
-                  "total_words: integer",
-                  "generated_at: date-time",
-                  "generator: string",
-                  "language: string",
-                  "description: string",
-                ]}
-              />
-            </div>
-
-            {/* grains column */}
-            <div
-              style={{ width: MAIN_COL }}
-              className="flex flex-col items-center"
-            >
-              <TreeNode
-                label="grains[]"
-                type="array"
-                fields={[
-                  "word: string *",
-                  "normalized: string",
-                  "pos: enum",
-                  "frequency: integer",
-                  "tfidf: number",
-                  "sentiment: enum",
-                  "categories: string[]",
-                  "contexts: Context[]",
-                  "collocations: Collocation[]",
-                ]}
-              />
-
-              <TreeConnector cols={2} colWidth={SUB_COL} />
-
-              <div className="flex" style={{ width: SUB_COL * 2 }}>
-                <div
-                  style={{ width: SUB_COL }}
-                  className="flex flex-col items-center"
-                >
-                  <TreeNode
-                    label="Context"
-                    type="object"
-                    small
-                    fields={[
-                      "line: string *",
-                      "track: string",
-                      "album: string",
-                      "year: integer",
-                    ]}
-                  />
-                </div>
-                <div
-                  style={{ width: SUB_COL }}
-                  className="flex flex-col items-center"
-                >
-                  <TreeNode
-                    label="Collocation"
-                    type="object"
-                    small
-                    fields={[
-                      "word: string *",
-                      "score: number *",
-                      "position: enum",
-                    ]}
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
+              {tab.label}
+            </button>
+          ))}
         </div>
       </div>
 
-      {/* Mobile Tree */}
-      <div className="mt-12 flex flex-col items-center sm:hidden">
-        <TreeNode
-          label="Document"
-          type="object"
-          accent
-          fields={["$schema", "meta", "grains[]"]}
-        />
-        <div className="h-4 w-px bg-zinc-300 dark:bg-zinc-600" />
-        <TreeNode
-          label="meta"
-          type="object"
-          fields={[
-            "source: string",
-            "artist: string",
-            "corpus_size: integer",
-            "total_words: integer",
-            "generated_at: date-time",
-            "generator: string",
-            "language: string",
-            "description: string",
-          ]}
-        />
-        <div className="h-4 w-px bg-zinc-300 dark:bg-zinc-600" />
-        <TreeNode
-          label="grains[]"
-          type="array"
-          fields={[
-            "word: string *",
-            "normalized: string",
-            "pos: enum",
-            "frequency: integer",
-            "tfidf: number",
-            "sentiment: enum",
-            "categories: string[]",
-            "contexts: Context[]",
-            "collocations: Collocation[]",
-          ]}
-        />
-        <div className="h-4 w-px bg-zinc-300 dark:bg-zinc-600" />
-        <div className="flex gap-4">
-          <TreeNode
-            label="Context"
-            type="object"
-            small
-            fields={[
-              "line: string *",
-              "track: string",
-              "album: string",
-              "year: integer",
-            ]}
-          />
-          <TreeNode
-            label="Collocation"
-            type="object"
-            small
-            fields={[
-              "word: string *",
-              "score: number *",
-              "position: enum",
-            ]}
-          />
-        </div>
-      </div>
+      {/* Word tree */}
+      {activeTab === "word" && <WordTree />}
+
+      {/* Bar tree */}
+      {activeTab === "bar" && <BarTree />}
+
+      {/* Verse placeholder */}
+      {activeTab === "verse" && <VersePlaceholder />}
 
       {/* Legend */}
       <div className="mt-10 flex flex-wrap items-center justify-center gap-6 text-xs text-zinc-500 dark:text-zinc-400">
@@ -195,14 +81,212 @@ export default function SchemaOverview() {
   );
 }
 
-/**
- * SVG connector that draws a T-shaped branch from a parent node
- * to `cols` child nodes arranged in equal-width columns.
- *
- *        |           ← vertical stem (from parent center)
- *    ────┼────       ← horizontal bar
- *    |       |       ← vertical drops (to each child center)
- */
+function WordTree() {
+  return (
+    <>
+      {/* Desktop */}
+      <div className="mt-8 hidden justify-center overflow-x-auto sm:flex">
+        <div className="flex flex-col items-center">
+          <TreeNode
+            label="Document"
+            type="object"
+            accent
+            fields={['type: "word"', "$schema", "schema_version", "meta", "grains[]"]}
+          />
+          <TreeConnector cols={2} colWidth={MAIN_COL} />
+          <div className="flex" style={{ width: MAIN_COL * 2 }}>
+            <div style={{ width: MAIN_COL }} className="flex flex-col items-center">
+              <TreeNode
+                label="meta"
+                type="object"
+                fields={[
+                  "source: string *",
+                  "artist: string *",
+                  "generated_at: date-time *",
+                  "corpus_size: integer",
+                  "total_words: integer",
+                  "language: string",
+                ]}
+              />
+            </div>
+            <div style={{ width: MAIN_COL }} className="flex flex-col items-center">
+              <TreeNode
+                label="grains[]"
+                type="array"
+                fields={[
+                  "word: string *",
+                  "normalized: string",
+                  "pos: enum",
+                  "frequency: integer",
+                  "tfidf: number",
+                  "sentiment: enum",
+                  "categories: string[]",
+                  "contexts: Context[]",
+                  "collocations: Collocation[]",
+                ]}
+              />
+              <TreeConnector cols={2} colWidth={SUB_COL} />
+              <div className="flex" style={{ width: SUB_COL * 2 }}>
+                <div style={{ width: SUB_COL }} className="flex flex-col items-center">
+                  <TreeNode
+                    label="Context"
+                    type="object"
+                    small
+                    fields={["line: string *", "track: string", "album: string", "year: integer"]}
+                  />
+                </div>
+                <div style={{ width: SUB_COL }} className="flex flex-col items-center">
+                  <TreeNode
+                    label="Collocation"
+                    type="object"
+                    small
+                    fields={["word: string *", "score: number *", "position: enum"]}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      {/* Mobile */}
+      <div className="mt-8 flex flex-col items-center sm:hidden">
+        <TreeNode
+          label="Document"
+          type="object"
+          accent
+          fields={['type: "word"', "$schema", "schema_version", "meta", "grains[]"]}
+        />
+        <div className="h-4 w-px bg-zinc-300 dark:bg-zinc-600" />
+        <TreeNode
+          label="meta"
+          type="object"
+          fields={["source *", "artist *", "generated_at *", "corpus_size", "total_words", "language"]}
+        />
+        <div className="h-4 w-px bg-zinc-300 dark:bg-zinc-600" />
+        <TreeNode
+          label="grains[]"
+          type="array"
+          fields={["word *", "pos", "frequency", "tfidf", "sentiment", "contexts[]"]}
+        />
+      </div>
+    </>
+  );
+}
+
+function BarTree() {
+  return (
+    <>
+      {/* Desktop */}
+      <div className="mt-8 hidden justify-center overflow-x-auto sm:flex">
+        <div className="flex flex-col items-center">
+          <TreeNode
+            label="Document"
+            type="object"
+            accent
+            fields={[
+              'type: "bar"',
+              "$schema",
+              "schema_version",
+              "text: string *",
+              "source *",
+              "metrics",
+              "semantics",
+              "language: string",
+            ]}
+          />
+          <TreeConnector cols={3} colWidth={240} />
+          <div className="flex" style={{ width: 240 * 3 }}>
+            <div style={{ width: 240 }} className="flex flex-col items-center">
+              <TreeNode
+                label="source"
+                type="object"
+                fields={[
+                  "artist: string *",
+                  "track: string *",
+                  "album: string",
+                  "year: integer",
+                  "featuring: string[]",
+                ]}
+              />
+            </div>
+            <div style={{ width: 240 }} className="flex flex-col items-center">
+              <TreeNode
+                label="metrics"
+                type="object"
+                fields={[
+                  "lines: integer",
+                  "syllables: integer",
+                  "mora: integer | null",
+                ]}
+              />
+            </div>
+            <div style={{ width: 240 }} className="flex flex-col items-center">
+              <TreeNode
+                label="semantics"
+                type="object"
+                fields={["mood: enum"]}
+              />
+              <div className="mt-3 rounded border border-zinc-200 bg-zinc-50 px-3 py-2 text-xs font-mono text-zinc-500 dark:border-zinc-700 dark:bg-zinc-800/50 dark:text-zinc-400">
+                <div className="mb-1 text-[10px] font-sans font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">mood values</div>
+                cold, defiant, melancholic,
+                <br />
+                aggressive, introspective,
+                <br />
+                celebratory, tender, weary
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      {/* Mobile */}
+      <div className="mt-8 flex flex-col items-center sm:hidden">
+        <TreeNode
+          label="Document"
+          type="object"
+          accent
+          fields={['type: "bar"', "text *", "source *", "metrics", "semantics", "language"]}
+        />
+        <div className="h-4 w-px bg-zinc-300 dark:bg-zinc-600" />
+        <TreeNode
+          label="source"
+          type="object"
+          fields={["artist *", "track *", "album", "year"]}
+        />
+        <div className="h-4 w-px bg-zinc-300 dark:bg-zinc-600" />
+        <div className="flex gap-4">
+          <TreeNode
+            label="metrics"
+            type="object"
+            small
+            fields={["lines", "syllables", "mora"]}
+          />
+          <TreeNode
+            label="semantics"
+            type="object"
+            small
+            fields={["mood: enum"]}
+          />
+        </div>
+      </div>
+    </>
+  );
+}
+
+function VersePlaceholder() {
+  return (
+    <div className="mt-8 flex justify-center">
+      <div className="rounded-lg border border-dashed border-zinc-300 bg-zinc-50/50 px-12 py-10 text-center dark:border-zinc-700 dark:bg-zinc-800/30">
+        <p className="text-sm font-medium text-zinc-500 dark:text-zinc-400">
+          The <code className="rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">verse</code> type is reserved for future specification.
+        </p>
+        <p className="mt-2 text-xs text-zinc-400 dark:text-zinc-500">
+          Detailed schema will be defined in a subsequent version.
+        </p>
+      </div>
+    </div>
+  );
+}
+
 function TreeConnector({
   cols,
   colWidth,
@@ -223,35 +307,10 @@ function TreeConnector({
         className="block text-zinc-300 dark:text-zinc-600"
         style={{ overflow: "visible" }}
       >
-        {/* Vertical stem from parent center */}
-        <line
-          x1={barWidth / 2}
-          y1={0}
-          x2={barWidth / 2}
-          y2={mid}
-          stroke="currentColor"
-          strokeWidth={1}
-        />
-        {/* Horizontal bar */}
-        <line
-          x1={0}
-          y1={mid}
-          x2={barWidth}
-          y2={mid}
-          stroke="currentColor"
-          strokeWidth={1}
-        />
-        {/* Vertical drops to children */}
+        <line x1={barWidth / 2} y1={0} x2={barWidth / 2} y2={mid} stroke="currentColor" strokeWidth={1} />
+        <line x1={0} y1={mid} x2={barWidth} y2={mid} stroke="currentColor" strokeWidth={1} />
         {Array.from({ length: cols }, (_, i) => (
-          <line
-            key={i}
-            x1={i * colWidth}
-            y1={mid}
-            x2={i * colWidth}
-            y2={h}
-            stroke="currentColor"
-            strokeWidth={1}
-          />
+          <line key={i} x1={i * colWidth} y1={mid} x2={i * colWidth} y2={h} stroke="currentColor" strokeWidth={1} />
         ))}
       </svg>
     </div>

--- a/site/components/playground/StatsSummary.tsx
+++ b/site/components/playground/StatsSummary.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useMemo } from "react";
-import type { WordGrainDocument, Grain } from "@/lib/types";
+import type { WordDocument, Grain } from "@/lib/types";
 
 interface StatsSummaryProps {
-  left: WordGrainDocument;
-  right: WordGrainDocument;
+  left: WordDocument;
+  right: WordDocument;
 }
 
 interface SentimentCounts {
@@ -30,7 +30,7 @@ interface CommonWord {
   rightTfidf: number | undefined;
 }
 
-function computeStats(doc: WordGrainDocument): DocumentStats {
+function computeStats(doc: WordDocument): DocumentStats {
   const grains = doc.grains;
   const grainCount = grains.length;
 
@@ -66,8 +66,8 @@ function computeStats(doc: WordGrainDocument): DocumentStats {
 }
 
 function findCommonWords(
-  left: WordGrainDocument,
-  right: WordGrainDocument
+  left: WordDocument,
+  right: WordDocument
 ): CommonWord[] {
   const rightMap = new Map<string, Grain>();
   for (const g of right.grains) {

--- a/site/lib/examples.ts
+++ b/site/lib/examples.ts
@@ -1,8 +1,9 @@
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? "/word-grain";
 
 export const EXAMPLES = [
-  { name: "Kendrick Lamar (Full)", path: `${BASE}/examples/kendrick-lamar.wg.json` },
-  { name: "Minimal", path: `${BASE}/examples/minimal.wg.json` },
+  { name: "Kendrick Lamar (Full)", path: `${BASE}/examples/kendrick-lamar.wg.json`, type: "word" as const },
+  { name: "Minimal", path: `${BASE}/examples/minimal.wg.json`, type: "word" as const },
+  { name: "KOHH - Bar", path: `${BASE}/examples/kohh-bar.wg.json`, type: "bar" as const },
 ] as const;
 
 export async function loadExample(path: string): Promise<string> {

--- a/site/lib/schema.ts
+++ b/site/lib/schema.ts
@@ -4,7 +4,7 @@ export async function loadSchema(): Promise<Record<string, unknown>> {
   if (cachedSchema) return cachedSchema;
 
   const res = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_PATH ?? "/word-grain"}/schema/v0.1.0/wordgrain.schema.json`
+    `${process.env.NEXT_PUBLIC_BASE_PATH ?? "/word-grain"}/schema/v0.2.0/wordgrain.schema.json`
   );
   cachedSchema = (await res.json()) as Record<string, unknown>;
   return cachedSchema;

--- a/site/lib/types.ts
+++ b/site/lib/types.ts
@@ -55,8 +55,58 @@ export interface Meta {
   description?: string;
 }
 
-export interface WordGrainDocument {
+export type Mood =
+  | "cold"
+  | "defiant"
+  | "melancholic"
+  | "aggressive"
+  | "introspective"
+  | "celebratory"
+  | "tender"
+  | "weary";
+
+export interface BarSource {
+  artist: string;
+  track: string;
+  album?: string;
+  year?: number;
+  featuring?: string[];
+}
+
+export interface BarMetrics {
+  lines?: number;
+  syllables?: number;
+  mora?: number | null;
+}
+
+export interface BarSemantics {
+  mood?: Mood;
+}
+
+export interface WordDocument {
   $schema: string;
+  schema_version: string;
+  type: "word";
   meta: Meta;
   grains: Grain[];
 }
+
+export interface BarDocument {
+  $schema: string;
+  schema_version: string;
+  type: "bar";
+  text: string;
+  source: BarSource;
+  metrics?: BarMetrics;
+  semantics?: BarSemantics;
+  language?: string;
+}
+
+export interface VerseDocument {
+  $schema: string;
+  schema_version: string;
+  type: "verse";
+  [key: string]: unknown;
+}
+
+export type WordGrainDocument = WordDocument | BarDocument | VerseDocument;

--- a/site/public/examples/kohh-bar.wg.json
+++ b/site/public/examples/kohh-bar.wg.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
+  "type": "bar",
+  "text": "俺はまだ関係ねえ 関係ねえ 関係ねえ",
+  "source": {
+    "artist": "KOHH",
+    "track": "貧乏なんて気にしない",
+    "album": "YELLOW T△PE 3",
+    "year": 2016
+  },
+  "metrics": {
+    "lines": 1,
+    "syllables": 18,
+    "mora": 20
+  },
+  "semantics": {
+    "mood": "defiant"
+  },
+  "language": "ja"
+}

--- a/site/public/schema/v0.2.0/wordgrain.schema.json
+++ b/site/public/schema/v0.2.0/wordgrain.schema.json
@@ -1,0 +1,387 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "title": "WordGrain",
+  "description": "A JSON format for storing vocabulary and lyrical structure data extracted from musical lyrics. Supports word (morpheme), bar (phrase/line), and verse (full verse) granularity levels.",
+  "type": "object",
+  "required": ["$schema", "schema_version", "type"],
+  "discriminator": {
+    "propertyName": "type"
+  },
+  "oneOf": [
+    { "$ref": "#/$defs/WordDocument" },
+    { "$ref": "#/$defs/BarDocument" },
+    { "$ref": "#/$defs/VerseDocument" }
+  ],
+  "$defs": {
+    "WordDocument": {
+      "type": "object",
+      "description": "Word-level (morpheme) grain document. Compatible with v0.1.0 structure.",
+      "required": ["$schema", "schema_version", "type", "meta", "grains"],
+      "additionalProperties": false,
+      "properties": {
+        "$schema": { "$ref": "#/$defs/SchemaUri" },
+        "schema_version": { "$ref": "#/$defs/SchemaVersion" },
+        "type": {
+          "const": "word"
+        },
+        "meta": { "$ref": "#/$defs/Meta" },
+        "grains": {
+          "type": "array",
+          "description": "Array of vocabulary grain entries",
+          "items": { "$ref": "#/$defs/Grain" },
+          "minItems": 0
+        }
+      }
+    },
+    "BarDocument": {
+      "type": "object",
+      "description": "Bar-level (phrase/line) grain document. Represents 1-2 lines of lyrics as a unit.",
+      "required": ["$schema", "schema_version", "type", "text", "source"],
+      "additionalProperties": false,
+      "properties": {
+        "$schema": { "$ref": "#/$defs/SchemaUri" },
+        "schema_version": { "$ref": "#/$defs/SchemaVersion" },
+        "type": {
+          "const": "bar"
+        },
+        "text": {
+          "type": "string",
+          "description": "The lyric text of the bar (1-2 lines)",
+          "minLength": 1
+        },
+        "source": { "$ref": "#/$defs/BarSource" },
+        "metrics": { "$ref": "#/$defs/BarMetrics" },
+        "semantics": { "$ref": "#/$defs/BarSemantics" },
+        "language": {
+          "type": "string",
+          "description": "ISO 639-1 language code",
+          "pattern": "^[a-z]{2}$",
+          "default": "en"
+        }
+      }
+    },
+    "VerseDocument": {
+      "type": "object",
+      "description": "Verse-level grain document. Represents a full verse. Detailed schema to be defined in a future version.",
+      "required": ["$schema", "schema_version", "type"],
+      "additionalProperties": true,
+      "properties": {
+        "$schema": { "$ref": "#/$defs/SchemaUri" },
+        "schema_version": { "$ref": "#/$defs/SchemaVersion" },
+        "type": {
+          "const": "verse"
+        }
+      }
+    },
+    "SchemaUri": {
+      "type": "string",
+      "format": "uri",
+      "description": "URI reference to the WordGrain schema version",
+      "pattern": "^https://raw\\.githubusercontent\\.com/shimpeiws/word-grain/main/schema/v[0-9]+\\.[0-9]+\\.[0-9]+/wordgrain\\.schema\\.json$"
+    },
+    "SchemaVersion": {
+      "type": "string",
+      "description": "Schema version identifier",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+      "examples": ["0.2.0"]
+    },
+    "BarSource": {
+      "type": "object",
+      "description": "Source information for a bar",
+      "required": ["artist", "track"],
+      "additionalProperties": false,
+      "properties": {
+        "artist": {
+          "type": "string",
+          "description": "Artist name",
+          "minLength": 1
+        },
+        "track": {
+          "type": "string",
+          "description": "Track/song title",
+          "minLength": 1
+        },
+        "album": {
+          "type": "string",
+          "description": "Album name"
+        },
+        "year": {
+          "type": "integer",
+          "description": "Release year",
+          "minimum": 1,
+          "maximum": 2200
+        },
+        "featuring": {
+          "type": "array",
+          "description": "Featured artists on this track",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "BarMetrics": {
+      "type": "object",
+      "description": "Quantitative metrics for a bar",
+      "additionalProperties": false,
+      "properties": {
+        "lines": {
+          "type": "integer",
+          "description": "Number of lines in the bar",
+          "minimum": 1
+        },
+        "syllables": {
+          "type": "integer",
+          "description": "Total syllable count",
+          "minimum": 0
+        },
+        "mora": {
+          "type": ["integer", "null"],
+          "description": "Mora count (for Japanese and other mora-timed languages). Null if not applicable.",
+          "minimum": 0
+        }
+      }
+    },
+    "BarSemantics": {
+      "type": "object",
+      "description": "Semantic attributes of a bar",
+      "additionalProperties": false,
+      "properties": {
+        "mood": {
+          "$ref": "#/$defs/Mood"
+        }
+      }
+    },
+    "Mood": {
+      "type": "string",
+      "description": "The dominant mood or emotional tone of the bar",
+      "enum": [
+        "cold",
+        "defiant",
+        "melancholic",
+        "aggressive",
+        "introspective",
+        "celebratory",
+        "tender",
+        "weary"
+      ]
+    },
+    "Meta": {
+      "type": "object",
+      "description": "Metadata about the WordGrain document",
+      "required": ["source", "artist", "generated_at"],
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "type": "string",
+          "description": "Data source identifier (e.g., 'genius', 'azlyrics', 'manual')",
+          "minLength": 1,
+          "examples": ["genius", "azlyrics", "spotify", "manual"]
+        },
+        "artist": {
+          "type": "string",
+          "description": "Primary artist name",
+          "minLength": 1
+        },
+        "artists": {
+          "type": "array",
+          "description": "Additional artists for collaborative corpora",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1
+        },
+        "corpus_size": {
+          "type": "integer",
+          "description": "Number of tracks analyzed",
+          "minimum": 0
+        },
+        "total_words": {
+          "type": "integer",
+          "description": "Total word count in analyzed corpus",
+          "minimum": 0
+        },
+        "generated_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp of document generation"
+        },
+        "generator": {
+          "type": "string",
+          "description": "Tool or pipeline that generated this document",
+          "examples": ["wordgrain-cli/1.0.0", "manual"]
+        },
+        "language": {
+          "type": "string",
+          "description": "ISO 639-1 language code",
+          "pattern": "^[a-z]{2}$",
+          "default": "en"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of this corpus"
+        }
+      }
+    },
+    "Grain": {
+      "type": "object",
+      "description": "A single vocabulary entry with linguistic and statistical data",
+      "required": ["word"],
+      "additionalProperties": false,
+      "properties": {
+        "word": {
+          "type": "string",
+          "description": "The vocabulary word or phrase",
+          "minLength": 1
+        },
+        "normalized": {
+          "type": "string",
+          "description": "Normalized/lemmatized form of the word",
+          "minLength": 1
+        },
+        "pos": {
+          "type": "string",
+          "description": "Part of speech tag",
+          "enum": [
+            "noun", "verb", "adjective", "adverb", "pronoun",
+            "preposition", "conjunction", "interjection",
+            "determiner", "particle", "other"
+          ]
+        },
+        "frequency": {
+          "type": "integer",
+          "description": "Raw occurrence count in corpus",
+          "minimum": 1
+        },
+        "frequency_normalized": {
+          "type": "number",
+          "description": "Frequency per 10,000 words",
+          "minimum": 0
+        },
+        "tfidf": {
+          "type": "number",
+          "description": "TF-IDF score (0.0 to 1.0)",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "sentiment": {
+          "type": "string",
+          "description": "Sentiment classification",
+          "enum": ["positive", "negative", "neutral", "mixed"]
+        },
+        "sentiment_score": {
+          "type": "number",
+          "description": "Sentiment score (-1.0 to 1.0)",
+          "minimum": -1,
+          "maximum": 1
+        },
+        "categories": {
+          "type": "array",
+          "description": "Semantic categories or tags",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "is_slang": {
+          "type": "boolean",
+          "description": "Whether the word is slang or non-standard"
+        },
+        "etymology": {
+          "type": "string",
+          "description": "Origin or etymology notes"
+        },
+        "definition": {
+          "type": "string",
+          "description": "Contextual definition within hip-hop culture"
+        },
+        "contexts": {
+          "type": "array",
+          "description": "Example usages from the corpus",
+          "items": { "$ref": "#/$defs/Context" },
+          "minItems": 1
+        },
+        "first_seen": {
+          "type": "string",
+          "description": "Earliest known usage (track or album)",
+          "minLength": 1
+        },
+        "collocations": {
+          "type": "array",
+          "description": "Frequently co-occurring words",
+          "items": { "$ref": "#/$defs/Collocation" }
+        },
+        "extensions": {
+          "type": "object",
+          "description": "Vendor-specific or experimental fields",
+          "additionalProperties": true
+        }
+      }
+    },
+    "Context": {
+      "type": "object",
+      "description": "A usage context from the lyrics corpus",
+      "required": ["line"],
+      "additionalProperties": false,
+      "properties": {
+        "line": {
+          "type": "string",
+          "description": "The lyric line containing the word",
+          "minLength": 1
+        },
+        "track": {
+          "type": "string",
+          "description": "Track/song title"
+        },
+        "album": {
+          "type": "string",
+          "description": "Album name"
+        },
+        "year": {
+          "type": "integer",
+          "description": "Release year",
+          "minimum": 1,
+          "maximum": 2200
+        },
+        "featuring": {
+          "type": "array",
+          "description": "Featured artists on this track",
+          "items": { "type": "string" }
+        },
+        "timestamp": {
+          "type": "string",
+          "description": "Timestamp in track (MM:SS format)",
+          "pattern": "^[0-9]{1,2}:[0-9]{2}$"
+        }
+      }
+    },
+    "Collocation": {
+      "type": "object",
+      "description": "A word that frequently appears with the grain word",
+      "required": ["word", "score"],
+      "additionalProperties": false,
+      "properties": {
+        "word": {
+          "type": "string",
+          "description": "The co-occurring word",
+          "minLength": 1
+        },
+        "score": {
+          "type": "number",
+          "description": "Collocation strength score (0.0 to 1.0)",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "position": {
+          "type": "string",
+          "description": "Typical position relative to grain word",
+          "enum": ["before", "after", "either"]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `BarDocument`, `VerseDocument`, `Mood`, `BarSource`, `BarMetrics`, `BarSemantics` types to `lib/types.ts`
- Update schema loader and playground to use v0.2.0 schema path
- Add KOHH bar example to example list and public assets
- Rewrite SchemaOverview with tab switching between word/bar/verse type trees
- Update HeroSection with bar/word code snippet toggle (bar shown by default)
- Handle discriminated union type in explorer (visualization only for word type)
- Handle discriminated union type in playground (stats comparison only for word type)

Closes #5