### PR TITLE
feat: unified document format (grains + bars) v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WordGrain Specification
 
-A JSON format for storing vocabulary data extracted from musical lyrics. Originally developed for hip-hop lyric analysis.
+A JSON format for storing vocabulary data and lyric bar analysis extracted from musical lyrics. Originally developed for hip-hop lyric analysis.
 
 ## Documentation
 
@@ -10,18 +10,22 @@ Full documentation is available at: https://shimpeiws.github.io/word-grain/
 
 WordGrain provides a standardized way to represent linguistic analysis of musical lyrics, including:
 
-- Vocabulary with frequency and TF-IDF scores
+- Vocabulary with frequency and TF-IDF scores (grains)
+- Lyric bar analysis with metrics and semantics (bars)
 - Part of speech and sentiment analysis
 - Contextual examples from actual lyrics
 - Collocation and usage patterns
 
+A single `.wg.json` file can contain `grains`, `bars`, or both.
+
 ## Quick Start
 
-### Minimal Example
+### Grains Example
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json",
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
   "meta": {
     "source": "genius",
     "artist": "Kendrick Lamar",
@@ -37,14 +41,36 @@ WordGrain provides a standardized way to represent linguistic analysis of musica
 }
 ```
 
+### Bars Example
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
+  "meta": {
+    "source": "manual",
+    "artist": "KOHH",
+    "generated_at": "2026-03-06T00:00:00Z",
+    "language": "ja"
+  },
+  "bars": [
+    {
+      "text": "結局俺は俺 お前はお前",
+      "source": { "track": "貧乏なんて気にしない", "album": "MONEYFLOWER", "year": 2017 },
+      "semantics": { "mood": "defiant", "themes": ["identity"] }
+    }
+  ]
+}
+```
+
 ### Validation
 
 ```bash
 # Using ajv-cli
-npx ajv validate -s schema/v0.1.0/wordgrain.schema.json -d your-file.wg.json
+npx ajv validate -s schema/v0.2.0/wordgrain.schema.json -d your-file.wg.json --spec=draft2020
 
 # Using Python jsonschema
-python -m jsonschema -i your-file.wg.json schema/v0.1.0/wordgrain.schema.json
+python -m jsonschema -i your-file.wg.json schema/v0.2.0/wordgrain.schema.json
 ```
 
 ## Specification
@@ -62,14 +88,16 @@ See [spec/WG-RFC-001.md](spec/WG-RFC-001.md) for the full specification.
 | File | Description |
 |------|-------------|
 | [examples/minimal.wg.json](examples/minimal.wg.json) | Minimal valid document |
-| [examples/kendrick-lamar.wg.json](examples/kendrick-lamar.wg.json) | Full-featured example |
+| [examples/kendrick-lamar.wg.json](examples/kendrick-lamar.wg.json) | Full-featured grains example |
+| [examples/kohh-bar.wg.json](examples/kohh-bar.wg.json) | Bars-only example |
+| [examples/mixed.wg.json](examples/mixed.wg.json) | Mixed grains + bars document |
 
 ## Schema
 
 The JSON Schema is available at:
 
-- Local: [schema/v0.1.0/wordgrain.schema.json](schema/v0.1.0/wordgrain.schema.json)
-- Remote: `https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json`
+- Local: [schema/v0.2.0/wordgrain.schema.json](schema/v0.2.0/wordgrain.schema.json)
+- Remote: `https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json`
 
 ## License
 

--- a/examples/kendrick-lamar.wg.json
+++ b/examples/kendrick-lamar.wg.json
@@ -1,5 +1,6 @@
 {
-  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json",
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
   "meta": {
     "source": "genius",
     "artist": "Kendrick Lamar",

--- a/examples/kohh-bar.wg.json
+++ b/examples/kohh-bar.wg.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
+  "meta": {
+    "source": "manual",
+    "artist": "KOHH",
+    "generated_at": "2026-03-06T00:00:00Z",
+    "language": "ja",
+    "description": "Selected bars from KOHH's discography"
+  },
+  "bars": [
+    {
+      "text": "結局俺は俺 お前はお前",
+      "source": {
+        "track": "貧乏なんて気にしない",
+        "album": "MONEYFLOWER",
+        "year": 2017
+      },
+      "metrics": {
+        "syllable_count": 14,
+        "word_count": 6
+      },
+      "semantics": {
+        "mood": "defiant",
+        "themes": ["identity", "independence"],
+        "techniques": ["repetition"]
+      },
+      "language": "ja"
+    },
+    {
+      "text": "It ain't safe no more",
+      "source": {
+        "track": "It Ain't Safe",
+        "album": "DIRT II",
+        "year": 2018,
+        "featuring": ["Loota"]
+      },
+      "metrics": {
+        "syllable_count": 5,
+        "word_count": 5
+      },
+      "semantics": {
+        "mood": "dark",
+        "themes": ["danger", "street-life"]
+      },
+      "language": "en"
+    }
+  ]
+}

--- a/examples/minimal.wg.json
+++ b/examples/minimal.wg.json
@@ -1,5 +1,6 @@
 {
-  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json",
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
   "meta": {
     "source": "manual",
     "artist": "Example Artist",

--- a/examples/mixed.wg.json
+++ b/examples/mixed.wg.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
+  "meta": {
+    "source": "manual",
+    "artist": "Kendrick Lamar",
+    "generated_at": "2026-03-06T00:00:00Z",
+    "language": "en",
+    "description": "Mixed document with both grains and bars from DAMN."
+  },
+  "grains": [
+    {
+      "word": "hustle",
+      "normalized": "hustle",
+      "pos": "noun",
+      "frequency": 47,
+      "tfidf": 0.82,
+      "sentiment": "positive",
+      "categories": ["work", "struggle", "ambition"]
+    }
+  ],
+  "bars": [
+    {
+      "text": "I got hustle though, ambition flow inside my DNA",
+      "source": {
+        "track": "DNA.",
+        "album": "DAMN.",
+        "year": 2017
+      },
+      "metrics": {
+        "syllable_count": 15,
+        "word_count": 10
+      },
+      "semantics": {
+        "mood": "aggressive",
+        "themes": ["ambition", "identity"],
+        "techniques": ["metaphor"]
+      }
+    }
+  ]
+}

--- a/schema/v0.2.0/wordgrain.schema.json
+++ b/schema/v0.2.0/wordgrain.schema.json
@@ -1,0 +1,406 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "title": "WordGrain",
+  "description": "A JSON format for storing vocabulary data and lyric bar analysis extracted from musical lyrics.",
+  "type": "object",
+  "required": ["$schema", "schema_version", "meta"],
+  "anyOf": [
+    { "required": ["grains"] },
+    { "required": ["bars"] }
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "description": "URI reference to the WordGrain schema version",
+      "pattern": "^https://raw\\.githubusercontent\\.com/shimpeiws/word-grain/main/schema/v[0-9]+\\.[0-9]+\\.[0-9]+/wordgrain\\.schema\\.json$"
+    },
+    "schema_version": {
+      "type": "string",
+      "description": "Schema version identifier",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+      "examples": ["0.2.0"]
+    },
+    "meta": {
+      "$ref": "#/$defs/Meta"
+    },
+    "grains": {
+      "type": "array",
+      "description": "Array of vocabulary grain entries",
+      "items": {
+        "$ref": "#/$defs/Grain"
+      },
+      "minItems": 0
+    },
+    "bars": {
+      "type": "array",
+      "description": "Array of lyric bar entries",
+      "items": {
+        "$ref": "#/$defs/Bar"
+      },
+      "minItems": 1
+    }
+  },
+  "$defs": {
+    "Meta": {
+      "type": "object",
+      "description": "Metadata about the WordGrain document",
+      "required": ["source", "artist", "generated_at"],
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "type": "string",
+          "description": "Data source identifier (e.g., 'genius', 'azlyrics', 'manual')",
+          "minLength": 1,
+          "examples": ["genius", "azlyrics", "spotify", "manual"]
+        },
+        "artist": {
+          "type": "string",
+          "description": "Primary artist name",
+          "minLength": 1
+        },
+        "artists": {
+          "type": "array",
+          "description": "Additional artists for collaborative corpora",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1
+        },
+        "corpus_size": {
+          "type": "integer",
+          "description": "Number of tracks analyzed",
+          "minimum": 0
+        },
+        "total_words": {
+          "type": "integer",
+          "description": "Total word count in analyzed corpus",
+          "minimum": 0
+        },
+        "generated_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp of document generation"
+        },
+        "generator": {
+          "type": "string",
+          "description": "Tool or pipeline that generated this document",
+          "examples": ["wordgrain-cli/1.0.0", "manual"]
+        },
+        "language": {
+          "type": "string",
+          "description": "ISO 639-1 language code",
+          "pattern": "^[a-z]{2}$",
+          "default": "en"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of this corpus"
+        }
+      }
+    },
+    "Grain": {
+      "type": "object",
+      "description": "A single vocabulary entry with linguistic and statistical data",
+      "required": ["word"],
+      "additionalProperties": false,
+      "properties": {
+        "word": {
+          "type": "string",
+          "description": "The vocabulary word or phrase",
+          "minLength": 1
+        },
+        "normalized": {
+          "type": "string",
+          "description": "Normalized/lemmatized form of the word",
+          "minLength": 1
+        },
+        "pos": {
+          "type": "string",
+          "description": "Part of speech tag",
+          "enum": [
+            "noun",
+            "verb",
+            "adjective",
+            "adverb",
+            "pronoun",
+            "preposition",
+            "conjunction",
+            "interjection",
+            "determiner",
+            "particle",
+            "other"
+          ]
+        },
+        "frequency": {
+          "type": "integer",
+          "description": "Raw occurrence count in corpus",
+          "minimum": 1
+        },
+        "frequency_normalized": {
+          "type": "number",
+          "description": "Frequency per 10,000 words",
+          "minimum": 0
+        },
+        "tfidf": {
+          "type": "number",
+          "description": "TF-IDF score (0.0 to 1.0)",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "sentiment": {
+          "type": "string",
+          "description": "Sentiment classification",
+          "enum": ["positive", "negative", "neutral", "mixed"]
+        },
+        "sentiment_score": {
+          "type": "number",
+          "description": "Sentiment score (-1.0 to 1.0)",
+          "minimum": -1,
+          "maximum": 1
+        },
+        "categories": {
+          "type": "array",
+          "description": "Semantic categories or tags",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "is_slang": {
+          "type": "boolean",
+          "description": "Whether the word is slang or non-standard"
+        },
+        "etymology": {
+          "type": "string",
+          "description": "Origin or etymology notes"
+        },
+        "definition": {
+          "type": "string",
+          "description": "Contextual definition within hip-hop culture"
+        },
+        "contexts": {
+          "type": "array",
+          "description": "Example usages from the corpus",
+          "items": {
+            "$ref": "#/$defs/Context"
+          },
+          "minItems": 1
+        },
+        "first_seen": {
+          "type": "string",
+          "description": "Earliest known usage (track or album)",
+          "minLength": 1
+        },
+        "collocations": {
+          "type": "array",
+          "description": "Frequently co-occurring words",
+          "items": {
+            "$ref": "#/$defs/Collocation"
+          }
+        },
+        "extensions": {
+          "type": "object",
+          "description": "Vendor-specific or experimental fields",
+          "additionalProperties": true
+        }
+      }
+    },
+    "Context": {
+      "type": "object",
+      "description": "A usage context from the lyrics corpus",
+      "required": ["line"],
+      "additionalProperties": false,
+      "properties": {
+        "line": {
+          "type": "string",
+          "description": "The lyric line containing the word",
+          "minLength": 1
+        },
+        "track": {
+          "type": "string",
+          "description": "Track/song title"
+        },
+        "album": {
+          "type": "string",
+          "description": "Album name"
+        },
+        "year": {
+          "type": "integer",
+          "description": "Release year",
+          "minimum": 1,
+          "maximum": 2200
+        },
+        "featuring": {
+          "type": "array",
+          "description": "Featured artists on this track",
+          "items": {
+            "type": "string"
+          }
+        },
+        "timestamp": {
+          "type": "string",
+          "description": "Timestamp in track (MM:SS format)",
+          "pattern": "^[0-9]{1,2}:[0-9]{2}$"
+        }
+      }
+    },
+    "Collocation": {
+      "type": "object",
+      "description": "A word that frequently appears with the grain word",
+      "required": ["word", "score"],
+      "additionalProperties": false,
+      "properties": {
+        "word": {
+          "type": "string",
+          "description": "The co-occurring word",
+          "minLength": 1
+        },
+        "score": {
+          "type": "number",
+          "description": "Collocation strength score (0.0 to 1.0)",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "position": {
+          "type": "string",
+          "description": "Typical position relative to grain word",
+          "enum": ["before", "after", "either"]
+        }
+      }
+    },
+    "Bar": {
+      "type": "object",
+      "description": "A lyric bar entry with source, metrics, and semantic analysis",
+      "required": ["text", "source"],
+      "additionalProperties": false,
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "The lyric bar text",
+          "minLength": 1
+        },
+        "source": {
+          "$ref": "#/$defs/BarSource"
+        },
+        "metrics": {
+          "$ref": "#/$defs/BarMetrics"
+        },
+        "semantics": {
+          "$ref": "#/$defs/BarSemantics"
+        },
+        "language": {
+          "type": "string",
+          "description": "ISO 639-1 language code for this bar",
+          "pattern": "^[a-z]{2}$"
+        }
+      }
+    },
+    "BarSource": {
+      "type": "object",
+      "description": "Source information for a bar",
+      "required": ["track"],
+      "additionalProperties": false,
+      "properties": {
+        "track": {
+          "type": "string",
+          "description": "Track/song title",
+          "minLength": 1
+        },
+        "album": {
+          "type": "string",
+          "description": "Album name"
+        },
+        "year": {
+          "type": "integer",
+          "description": "Release year",
+          "minimum": 1,
+          "maximum": 2200
+        },
+        "featuring": {
+          "type": "array",
+          "description": "Featured artists on this track",
+          "items": {
+            "type": "string"
+          }
+        },
+        "timestamp": {
+          "type": "string",
+          "description": "Timestamp in track (MM:SS format)",
+          "pattern": "^[0-9]{1,2}:[0-9]{2}$"
+        }
+      }
+    },
+    "BarMetrics": {
+      "type": "object",
+      "description": "Quantitative metrics for a bar",
+      "additionalProperties": false,
+      "properties": {
+        "syllable_count": {
+          "type": "integer",
+          "description": "Number of syllables",
+          "minimum": 1
+        },
+        "word_count": {
+          "type": "integer",
+          "description": "Number of words",
+          "minimum": 1
+        },
+        "rhyme_density": {
+          "type": "number",
+          "description": "Rhyme density score (0.0 to 1.0)",
+          "minimum": 0,
+          "maximum": 1
+        }
+      }
+    },
+    "BarSemantics": {
+      "type": "object",
+      "description": "Semantic analysis of a bar",
+      "additionalProperties": false,
+      "properties": {
+        "mood": {
+          "$ref": "#/$defs/Mood"
+        },
+        "themes": {
+          "type": "array",
+          "description": "Thematic tags",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "techniques": {
+          "type": "array",
+          "description": "Lyrical techniques used (e.g., metaphor, simile, wordplay)",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "Mood": {
+      "type": "string",
+      "description": "Mood classification",
+      "enum": [
+        "aggressive",
+        "melancholic",
+        "triumphant",
+        "reflective",
+        "humorous",
+        "romantic",
+        "defiant",
+        "hopeful",
+        "dark",
+        "celebratory"
+      ]
+    }
+  }
+}

--- a/site/app/explorer/page.tsx
+++ b/site/app/explorer/page.tsx
@@ -94,21 +94,21 @@ export default function ExplorerPage() {
                   <h2 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
                     Word Cloud
                   </h2>
-                  <WordCloudViz grains={validatedData.grains} />
+                  <WordCloudViz grains={validatedData.grains ?? []} />
                 </section>
 
                 <section>
                   <h2 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
                     Top Words by Frequency
                   </h2>
-                  <FrequencyChart grains={validatedData.grains} />
+                  <FrequencyChart grains={validatedData.grains ?? []} />
                 </section>
 
                 <section>
                   <h2 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
                     Grain Data
                   </h2>
-                  <GrainDataTable grains={validatedData.grains} />
+                  <GrainDataTable grains={validatedData.grains ?? []} />
                 </section>
               </>
             )}

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -4,34 +4,28 @@ import FeatureCards from "@/components/landing/FeatureCards";
 import EcosystemSection from "@/components/landing/EcosystemSection";
 
 const EXAMPLE_JSON = `{
-  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json",
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
   "meta": {
     "source": "genius",
     "artist": "Kendrick Lamar",
-    "corpus_size": 142,
-    "total_words": 89420,
     "generated_at": "2026-02-08T12:00:00Z",
-    "generator": "wordgrain-cli/0.1.0",
-    "language": "en",
-    "description": "Vocabulary analysis of Kendrick Lamar's studio albums (2011-2024)"
+    "language": "en"
   },
   "grains": [
     {
       "word": "hustle",
-      "normalized": "hustle",
-      "pos": "noun",
       "frequency": 47,
       "tfidf": 0.82,
       "sentiment": "positive",
-      "categories": ["work", "struggle", "ambition"],
-      "contexts": [
-        {
-          "line": "The hustle never sleeps, I grind until the sun comes up",
-          "track": "Money Trees",
-          "album": "good kid, m.A.A.d city",
-          "year": 2012
-        }
-      ]
+      "categories": ["work", "struggle", "ambition"]
+    }
+  ],
+  "bars": [
+    {
+      "text": "I got hustle though, ambition flow inside my DNA",
+      "source": { "track": "DNA.", "album": "DAMN.", "year": 2017 },
+      "semantics": { "mood": "aggressive", "themes": ["ambition"] }
     }
   ]
 }`;

--- a/site/app/playground/page.tsx
+++ b/site/app/playground/page.tsx
@@ -18,7 +18,7 @@ export default function PlaygroundPage() {
 
   // Fetch schema on mount
   useEffect(() => {
-    fetch("/word-grain/schema/v0.1.0/wordgrain.schema.json")
+    fetch("/word-grain/schema/v0.2.0/wordgrain.schema.json")
       .then((res) => {
         if (!res.ok) throw new Error("Failed to load schema");
         return res.json();

--- a/site/app/spec/page.tsx
+++ b/site/app/spec/page.tsx
@@ -99,7 +99,7 @@ export default function SpecPage() {
       try {
         const [mdRes, schemaRes] = await Promise.all([
           fetch(`${BASE_PATH}/spec/WG-RFC-001.md`),
-          fetch(`${BASE_PATH}/schema/v0.1.0/wordgrain.schema.json`),
+          fetch(`${BASE_PATH}/schema/v0.2.0/wordgrain.schema.json`),
         ]);
 
         if (!mdRes.ok) throw new Error(`Failed to load spec: ${mdRes.status}`);

--- a/site/components/landing/SchemaOverview.tsx
+++ b/site/components/landing/SchemaOverview.tsx
@@ -21,12 +21,12 @@ export default function SchemaOverview() {
             label="Document"
             type="object"
             accent
-            fields={["$schema", "meta", "grains[]"]}
+            fields={["$schema", "schema_version", "meta", "grains[]?", "bars[]?"]}
           />
 
-          <TreeConnector cols={2} colWidth={MAIN_COL} />
+          <TreeConnector cols={3} colWidth={MAIN_COL} />
 
-          <div className="flex" style={{ width: MAIN_COL * 2 }}>
+          <div className="flex" style={{ width: MAIN_COL * 3 }}>
             {/* meta column */}
             <div
               style={{ width: MAIN_COL }}
@@ -105,6 +105,59 @@ export default function SchemaOverview() {
                 </div>
               </div>
             </div>
+
+            {/* bars column */}
+            <div
+              style={{ width: MAIN_COL }}
+              className="flex flex-col items-center"
+            >
+              <TreeNode
+                label="bars[]"
+                type="array"
+                fields={[
+                  "text: string *",
+                  "source: BarSource *",
+                  "metrics: BarMetrics",
+                  "semantics: BarSemantics",
+                  "language: string",
+                ]}
+              />
+
+              <TreeConnector cols={2} colWidth={SUB_COL} />
+
+              <div className="flex" style={{ width: SUB_COL * 2 }}>
+                <div
+                  style={{ width: SUB_COL }}
+                  className="flex flex-col items-center"
+                >
+                  <TreeNode
+                    label="BarSource"
+                    type="object"
+                    small
+                    fields={[
+                      "track: string *",
+                      "album: string",
+                      "year: integer",
+                    ]}
+                  />
+                </div>
+                <div
+                  style={{ width: SUB_COL }}
+                  className="flex flex-col items-center"
+                >
+                  <TreeNode
+                    label="BarSemantics"
+                    type="object"
+                    small
+                    fields={[
+                      "mood: enum",
+                      "themes: string[]",
+                      "techniques: string[]",
+                    ]}
+                  />
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -115,7 +168,7 @@ export default function SchemaOverview() {
           label="Document"
           type="object"
           accent
-          fields={["$schema", "meta", "grains[]"]}
+          fields={["$schema", "schema_version", "meta", "grains[]?", "bars[]?"]}
         />
         <div className="h-4 w-px bg-zinc-300 dark:bg-zinc-600" />
         <TreeNode
@@ -169,6 +222,41 @@ export default function SchemaOverview() {
               "word: string *",
               "score: number *",
               "position: enum",
+            ]}
+          />
+        </div>
+        <div className="h-4 w-px bg-zinc-300 dark:bg-zinc-600" />
+        <TreeNode
+          label="bars[]"
+          type="array"
+          fields={[
+            "text: string *",
+            "source: BarSource *",
+            "metrics: BarMetrics",
+            "semantics: BarSemantics",
+            "language: string",
+          ]}
+        />
+        <div className="h-4 w-px bg-zinc-300 dark:bg-zinc-600" />
+        <div className="flex gap-4">
+          <TreeNode
+            label="BarSource"
+            type="object"
+            small
+            fields={[
+              "track: string *",
+              "album: string",
+              "year: integer",
+            ]}
+          />
+          <TreeNode
+            label="BarSemantics"
+            type="object"
+            small
+            fields={[
+              "mood: enum",
+              "themes: string[]",
+              "techniques: string[]",
             ]}
           />
         </div>

--- a/site/components/layout/Footer.tsx
+++ b/site/components/layout/Footer.tsx
@@ -2,7 +2,7 @@ export default function Footer() {
   return (
     <footer className="border-t border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950">
       <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-6 text-sm text-zinc-500 dark:text-zinc-400">
-        <span>WordGrain v0.1.0</span>
+        <span>WordGrain v0.2.0</span>
         <div className="flex gap-4">
           <a
             href="https://github.com/shimpeiws/word-grain"

--- a/site/components/playground/ComparisonView.tsx
+++ b/site/components/playground/ComparisonView.tsx
@@ -9,6 +9,8 @@ import type { ValidationResult } from "@/lib/validation";
 const EXAMPLES = [
   { label: "Kendrick Lamar", file: "kendrick-lamar.wg.json" },
   { label: "Minimal", file: "minimal.wg.json" },
+  { label: "KOHH Bars", file: "kohh-bar.wg.json" },
+  { label: "Mixed", file: "mixed.wg.json" },
 ] as const;
 
 interface ComparisonViewProps {

--- a/site/components/playground/StatsSummary.tsx
+++ b/site/components/playground/StatsSummary.tsx
@@ -31,7 +31,7 @@ interface CommonWord {
 }
 
 function computeStats(doc: WordGrainDocument): DocumentStats {
-  const grains = doc.grains;
+  const grains = doc.grains ?? [];
   const grainCount = grains.length;
 
   const withFreq = grains.filter(
@@ -70,13 +70,13 @@ function findCommonWords(
   right: WordGrainDocument
 ): CommonWord[] {
   const rightMap = new Map<string, Grain>();
-  for (const g of right.grains) {
+  for (const g of right.grains ?? []) {
     const key = (g.normalized ?? g.word).toLowerCase();
     rightMap.set(key, g);
   }
 
   const common: CommonWord[] = [];
-  for (const g of left.grains) {
+  for (const g of left.grains ?? []) {
     const key = (g.normalized ?? g.word).toLowerCase();
     const match = rightMap.get(key);
     if (match) {

--- a/site/lib/examples.ts
+++ b/site/lib/examples.ts
@@ -3,6 +3,8 @@ const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? "/word-grain";
 export const EXAMPLES = [
   { name: "Kendrick Lamar (Full)", path: `${BASE}/examples/kendrick-lamar.wg.json` },
   { name: "Minimal", path: `${BASE}/examples/minimal.wg.json` },
+  { name: "KOHH Bars", path: `${BASE}/examples/kohh-bar.wg.json` },
+  { name: "Mixed (Grains + Bars)", path: `${BASE}/examples/mixed.wg.json` },
 ] as const;
 
 export async function loadExample(path: string): Promise<string> {

--- a/site/lib/schema.ts
+++ b/site/lib/schema.ts
@@ -4,7 +4,7 @@ export async function loadSchema(): Promise<Record<string, unknown>> {
   if (cachedSchema) return cachedSchema;
 
   const res = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_PATH ?? "/word-grain"}/schema/v0.1.0/wordgrain.schema.json`
+    `${process.env.NEXT_PUBLIC_BASE_PATH ?? "/word-grain"}/schema/v0.2.0/wordgrain.schema.json`
   );
   cachedSchema = (await res.json()) as Record<string, unknown>;
   return cachedSchema;

--- a/site/lib/types.ts
+++ b/site/lib/types.ts
@@ -55,8 +55,48 @@ export interface Meta {
   description?: string;
 }
 
+export interface BarSource {
+  track: string;
+  album?: string;
+  year?: number;
+  featuring?: string[];
+  timestamp?: string;
+}
+
+export interface BarMetrics {
+  syllable_count?: number;
+  word_count?: number;
+  rhyme_density?: number;
+}
+
+export interface BarSemantics {
+  mood?:
+    | "aggressive"
+    | "melancholic"
+    | "triumphant"
+    | "reflective"
+    | "humorous"
+    | "romantic"
+    | "defiant"
+    | "hopeful"
+    | "dark"
+    | "celebratory";
+  themes?: string[];
+  techniques?: string[];
+}
+
+export interface Bar {
+  text: string;
+  source: BarSource;
+  metrics?: BarMetrics;
+  semantics?: BarSemantics;
+  language?: string;
+}
+
 export interface WordGrainDocument {
   $schema: string;
+  schema_version: string;
   meta: Meta;
-  grains: Grain[];
+  grains?: Grain[];
+  bars?: Bar[];
 }

--- a/site/public/examples/kendrick-lamar.wg.json
+++ b/site/public/examples/kendrick-lamar.wg.json
@@ -1,5 +1,6 @@
 {
-  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json",
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
   "meta": {
     "source": "genius",
     "artist": "Kendrick Lamar",

--- a/site/public/examples/kohh-bar.wg.json
+++ b/site/public/examples/kohh-bar.wg.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
+  "meta": {
+    "source": "manual",
+    "artist": "KOHH",
+    "generated_at": "2026-03-06T00:00:00Z",
+    "language": "ja",
+    "description": "Selected bars from KOHH's discography"
+  },
+  "bars": [
+    {
+      "text": "結局俺は俺 お前はお前",
+      "source": {
+        "track": "貧乏なんて気にしない",
+        "album": "MONEYFLOWER",
+        "year": 2017
+      },
+      "metrics": {
+        "syllable_count": 14,
+        "word_count": 6
+      },
+      "semantics": {
+        "mood": "defiant",
+        "themes": ["identity", "independence"],
+        "techniques": ["repetition"]
+      },
+      "language": "ja"
+    },
+    {
+      "text": "It ain't safe no more",
+      "source": {
+        "track": "It Ain't Safe",
+        "album": "DIRT II",
+        "year": 2018,
+        "featuring": ["Loota"]
+      },
+      "metrics": {
+        "syllable_count": 5,
+        "word_count": 5
+      },
+      "semantics": {
+        "mood": "dark",
+        "themes": ["danger", "street-life"]
+      },
+      "language": "en"
+    }
+  ]
+}

--- a/site/public/examples/minimal.wg.json
+++ b/site/public/examples/minimal.wg.json
@@ -1,5 +1,6 @@
 {
-  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json",
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
   "meta": {
     "source": "manual",
     "artist": "Example Artist",

--- a/site/public/examples/mixed.wg.json
+++ b/site/public/examples/mixed.wg.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
+  "meta": {
+    "source": "manual",
+    "artist": "Kendrick Lamar",
+    "generated_at": "2026-03-06T00:00:00Z",
+    "language": "en",
+    "description": "Mixed document with both grains and bars from DAMN."
+  },
+  "grains": [
+    {
+      "word": "hustle",
+      "normalized": "hustle",
+      "pos": "noun",
+      "frequency": 47,
+      "tfidf": 0.82,
+      "sentiment": "positive",
+      "categories": ["work", "struggle", "ambition"]
+    }
+  ],
+  "bars": [
+    {
+      "text": "I got hustle though, ambition flow inside my DNA",
+      "source": {
+        "track": "DNA.",
+        "album": "DAMN.",
+        "year": 2017
+      },
+      "metrics": {
+        "syllable_count": 15,
+        "word_count": 10
+      },
+      "semantics": {
+        "mood": "aggressive",
+        "themes": ["ambition", "identity"],
+        "techniques": ["metaphor"]
+      }
+    }
+  ]
+}

--- a/site/public/schema/v0.2.0/wordgrain.schema.json
+++ b/site/public/schema/v0.2.0/wordgrain.schema.json
@@ -1,0 +1,406 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "title": "WordGrain",
+  "description": "A JSON format for storing vocabulary data and lyric bar analysis extracted from musical lyrics.",
+  "type": "object",
+  "required": ["$schema", "schema_version", "meta"],
+  "anyOf": [
+    { "required": ["grains"] },
+    { "required": ["bars"] }
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "description": "URI reference to the WordGrain schema version",
+      "pattern": "^https://raw\\.githubusercontent\\.com/shimpeiws/word-grain/main/schema/v[0-9]+\\.[0-9]+\\.[0-9]+/wordgrain\\.schema\\.json$"
+    },
+    "schema_version": {
+      "type": "string",
+      "description": "Schema version identifier",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+      "examples": ["0.2.0"]
+    },
+    "meta": {
+      "$ref": "#/$defs/Meta"
+    },
+    "grains": {
+      "type": "array",
+      "description": "Array of vocabulary grain entries",
+      "items": {
+        "$ref": "#/$defs/Grain"
+      },
+      "minItems": 0
+    },
+    "bars": {
+      "type": "array",
+      "description": "Array of lyric bar entries",
+      "items": {
+        "$ref": "#/$defs/Bar"
+      },
+      "minItems": 1
+    }
+  },
+  "$defs": {
+    "Meta": {
+      "type": "object",
+      "description": "Metadata about the WordGrain document",
+      "required": ["source", "artist", "generated_at"],
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "type": "string",
+          "description": "Data source identifier (e.g., 'genius', 'azlyrics', 'manual')",
+          "minLength": 1,
+          "examples": ["genius", "azlyrics", "spotify", "manual"]
+        },
+        "artist": {
+          "type": "string",
+          "description": "Primary artist name",
+          "minLength": 1
+        },
+        "artists": {
+          "type": "array",
+          "description": "Additional artists for collaborative corpora",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1
+        },
+        "corpus_size": {
+          "type": "integer",
+          "description": "Number of tracks analyzed",
+          "minimum": 0
+        },
+        "total_words": {
+          "type": "integer",
+          "description": "Total word count in analyzed corpus",
+          "minimum": 0
+        },
+        "generated_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp of document generation"
+        },
+        "generator": {
+          "type": "string",
+          "description": "Tool or pipeline that generated this document",
+          "examples": ["wordgrain-cli/1.0.0", "manual"]
+        },
+        "language": {
+          "type": "string",
+          "description": "ISO 639-1 language code",
+          "pattern": "^[a-z]{2}$",
+          "default": "en"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of this corpus"
+        }
+      }
+    },
+    "Grain": {
+      "type": "object",
+      "description": "A single vocabulary entry with linguistic and statistical data",
+      "required": ["word"],
+      "additionalProperties": false,
+      "properties": {
+        "word": {
+          "type": "string",
+          "description": "The vocabulary word or phrase",
+          "minLength": 1
+        },
+        "normalized": {
+          "type": "string",
+          "description": "Normalized/lemmatized form of the word",
+          "minLength": 1
+        },
+        "pos": {
+          "type": "string",
+          "description": "Part of speech tag",
+          "enum": [
+            "noun",
+            "verb",
+            "adjective",
+            "adverb",
+            "pronoun",
+            "preposition",
+            "conjunction",
+            "interjection",
+            "determiner",
+            "particle",
+            "other"
+          ]
+        },
+        "frequency": {
+          "type": "integer",
+          "description": "Raw occurrence count in corpus",
+          "minimum": 1
+        },
+        "frequency_normalized": {
+          "type": "number",
+          "description": "Frequency per 10,000 words",
+          "minimum": 0
+        },
+        "tfidf": {
+          "type": "number",
+          "description": "TF-IDF score (0.0 to 1.0)",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "sentiment": {
+          "type": "string",
+          "description": "Sentiment classification",
+          "enum": ["positive", "negative", "neutral", "mixed"]
+        },
+        "sentiment_score": {
+          "type": "number",
+          "description": "Sentiment score (-1.0 to 1.0)",
+          "minimum": -1,
+          "maximum": 1
+        },
+        "categories": {
+          "type": "array",
+          "description": "Semantic categories or tags",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "is_slang": {
+          "type": "boolean",
+          "description": "Whether the word is slang or non-standard"
+        },
+        "etymology": {
+          "type": "string",
+          "description": "Origin or etymology notes"
+        },
+        "definition": {
+          "type": "string",
+          "description": "Contextual definition within hip-hop culture"
+        },
+        "contexts": {
+          "type": "array",
+          "description": "Example usages from the corpus",
+          "items": {
+            "$ref": "#/$defs/Context"
+          },
+          "minItems": 1
+        },
+        "first_seen": {
+          "type": "string",
+          "description": "Earliest known usage (track or album)",
+          "minLength": 1
+        },
+        "collocations": {
+          "type": "array",
+          "description": "Frequently co-occurring words",
+          "items": {
+            "$ref": "#/$defs/Collocation"
+          }
+        },
+        "extensions": {
+          "type": "object",
+          "description": "Vendor-specific or experimental fields",
+          "additionalProperties": true
+        }
+      }
+    },
+    "Context": {
+      "type": "object",
+      "description": "A usage context from the lyrics corpus",
+      "required": ["line"],
+      "additionalProperties": false,
+      "properties": {
+        "line": {
+          "type": "string",
+          "description": "The lyric line containing the word",
+          "minLength": 1
+        },
+        "track": {
+          "type": "string",
+          "description": "Track/song title"
+        },
+        "album": {
+          "type": "string",
+          "description": "Album name"
+        },
+        "year": {
+          "type": "integer",
+          "description": "Release year",
+          "minimum": 1,
+          "maximum": 2200
+        },
+        "featuring": {
+          "type": "array",
+          "description": "Featured artists on this track",
+          "items": {
+            "type": "string"
+          }
+        },
+        "timestamp": {
+          "type": "string",
+          "description": "Timestamp in track (MM:SS format)",
+          "pattern": "^[0-9]{1,2}:[0-9]{2}$"
+        }
+      }
+    },
+    "Collocation": {
+      "type": "object",
+      "description": "A word that frequently appears with the grain word",
+      "required": ["word", "score"],
+      "additionalProperties": false,
+      "properties": {
+        "word": {
+          "type": "string",
+          "description": "The co-occurring word",
+          "minLength": 1
+        },
+        "score": {
+          "type": "number",
+          "description": "Collocation strength score (0.0 to 1.0)",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "position": {
+          "type": "string",
+          "description": "Typical position relative to grain word",
+          "enum": ["before", "after", "either"]
+        }
+      }
+    },
+    "Bar": {
+      "type": "object",
+      "description": "A lyric bar entry with source, metrics, and semantic analysis",
+      "required": ["text", "source"],
+      "additionalProperties": false,
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "The lyric bar text",
+          "minLength": 1
+        },
+        "source": {
+          "$ref": "#/$defs/BarSource"
+        },
+        "metrics": {
+          "$ref": "#/$defs/BarMetrics"
+        },
+        "semantics": {
+          "$ref": "#/$defs/BarSemantics"
+        },
+        "language": {
+          "type": "string",
+          "description": "ISO 639-1 language code for this bar",
+          "pattern": "^[a-z]{2}$"
+        }
+      }
+    },
+    "BarSource": {
+      "type": "object",
+      "description": "Source information for a bar",
+      "required": ["track"],
+      "additionalProperties": false,
+      "properties": {
+        "track": {
+          "type": "string",
+          "description": "Track/song title",
+          "minLength": 1
+        },
+        "album": {
+          "type": "string",
+          "description": "Album name"
+        },
+        "year": {
+          "type": "integer",
+          "description": "Release year",
+          "minimum": 1,
+          "maximum": 2200
+        },
+        "featuring": {
+          "type": "array",
+          "description": "Featured artists on this track",
+          "items": {
+            "type": "string"
+          }
+        },
+        "timestamp": {
+          "type": "string",
+          "description": "Timestamp in track (MM:SS format)",
+          "pattern": "^[0-9]{1,2}:[0-9]{2}$"
+        }
+      }
+    },
+    "BarMetrics": {
+      "type": "object",
+      "description": "Quantitative metrics for a bar",
+      "additionalProperties": false,
+      "properties": {
+        "syllable_count": {
+          "type": "integer",
+          "description": "Number of syllables",
+          "minimum": 1
+        },
+        "word_count": {
+          "type": "integer",
+          "description": "Number of words",
+          "minimum": 1
+        },
+        "rhyme_density": {
+          "type": "number",
+          "description": "Rhyme density score (0.0 to 1.0)",
+          "minimum": 0,
+          "maximum": 1
+        }
+      }
+    },
+    "BarSemantics": {
+      "type": "object",
+      "description": "Semantic analysis of a bar",
+      "additionalProperties": false,
+      "properties": {
+        "mood": {
+          "$ref": "#/$defs/Mood"
+        },
+        "themes": {
+          "type": "array",
+          "description": "Thematic tags",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "techniques": {
+          "type": "array",
+          "description": "Lyrical techniques used (e.g., metaphor, simile, wordplay)",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "Mood": {
+      "type": "string",
+      "description": "Mood classification",
+      "enum": [
+        "aggressive",
+        "melancholic",
+        "triumphant",
+        "reflective",
+        "humorous",
+        "romantic",
+        "defiant",
+        "hopeful",
+        "dark",
+        "celebratory"
+      ]
+    }
+  }
+}

--- a/spec/WG-RFC-001.md
+++ b/spec/WG-RFC-001.md
@@ -1,4 +1,4 @@
-# WG-RFC-001: WordGrain Specification v0.1.0
+# WG-RFC-001: WordGrain Specification v0.2.0
 
 | Field | Value |
 |-------|-------|
@@ -6,13 +6,14 @@
 | Title | WordGrain JSON Format Specification |
 | Status | Draft |
 | Created | 2026-02-08 |
+| Updated | 2026-03-06 |
 | Author | Shin Takamatsu |
 
 ---
 
 ## Abstract
 
-WordGrain is a standardized JSON format for representing vocabulary data extracted from musical lyrics and other text sources. This specification defines the structure, fields, and validation rules for WordGrain documents.
+WordGrain is a standardized JSON format for representing vocabulary data and lyric bar analysis extracted from musical lyrics and other text sources. This specification defines the structure, fields, and validation rules for WordGrain documents.
 
 ---
 
@@ -21,14 +22,15 @@ WordGrain is a standardized JSON format for representing vocabulary data extract
 1. [Motivation](#1-motivation)
 2. [Terminology](#2-terminology)
 3. [Specification](#3-specification)
-4. [File Conventions](#4-file-conventions)
-5. [Versioning](#5-versioning)
-6. [MIME Type](#6-mime-type)
-7. [Examples](#7-examples)
-8. [Validation](#8-validation)
-9. [Security Considerations](#9-security-considerations)
-10. [Future Extensions](#10-future-extensions)
-11. [References](#11-references)
+4. [Content Sections](#4-content-sections)
+5. [File Conventions](#5-file-conventions)
+6. [Versioning](#6-versioning)
+7. [MIME Type](#7-mime-type)
+8. [Examples](#8-examples)
+9. [Validation](#9-validation)
+10. [Security Considerations](#10-security-considerations)
+11. [Future Extensions](#11-future-extensions)
+12. [References](#12-references)
 
 ---
 
@@ -42,6 +44,7 @@ Musical lyrics represent a rich linguistic corpus with unique vocabulary, slang 
 - Archiving linguistic patterns in musical lyrics
 - Building educational and research applications
 - Creating interoperable lyric analysis pipelines
+- Storing structured bar-level lyric analysis
 
 ### 1.2 Goals
 
@@ -50,6 +53,7 @@ Musical lyrics represent a rich linguistic corpus with unique vocabulary, slang 
 3. **Extensibility**: Allow future additions without breaking changes
 4. **Simplicity**: Keep the core format minimal and human-readable
 5. **Validation**: Provide machine-verifiable schema
+6. **Unified Format**: Support multiple content types (grains, bars) in a single document
 
 ### 1.3 Non-Goals
 
@@ -66,6 +70,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 | Term | Definition |
 |------|------------|
 | Grain | A single vocabulary entry with associated metadata |
+| Bar | A lyric line or phrase with source, metrics, and semantic analysis |
 | Corpus | The collection of lyrics analyzed to produce grains |
 | Context | A specific usage instance of a word in lyrics |
 | TF-IDF | Term Frequency-Inverse Document Frequency score |
@@ -76,21 +81,27 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### 3.1 Document Structure
 
-A WordGrain document is a JSON object with three top-level properties:
+A WordGrain document is a unified JSON object that can contain vocabulary grains, lyric bars, or both. At least one of `grains` or `bars` MUST be present.
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json",
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
   "meta": { ... },
-  "grains": [ ... ]
+  "grains": [ ... ],
+  "bars": [ ... ]
 }
 ```
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
 | `$schema` | string (URI) | REQUIRED | Schema version URI |
+| `schema_version` | string | REQUIRED | Schema version identifier (e.g., "0.2.0") |
 | `meta` | object | REQUIRED | Document metadata |
-| `grains` | array | REQUIRED | Array of grain objects |
+| `grains` | array | OPTIONAL* | Array of grain objects |
+| `bars` | array | OPTIONAL* | Array of bar objects |
+
+\* At least one of `grains` or `bars` MUST be present.
 
 ### 3.2 Meta Object
 
@@ -198,9 +209,64 @@ Extension keys SHOULD be prefixed with `x-` to indicate non-standard fields.
 
 ---
 
-## 4. File Conventions
+## 4. Content Sections
 
-### 4.1 File Extension
+A WordGrain document supports two content sections: **grains** for vocabulary analysis and **bars** for lyric-level analysis. At least one section MUST be present; both MAY coexist in a single document.
+
+### 4.1 Grains Section
+
+The `grains` array contains vocabulary entries with linguistic and statistical data. See Section 3.3 for the Grain object structure.
+
+### 4.2 Bars Section
+
+The `bars` array contains lyric bar entries. Each bar is an individual lyric line or phrase with associated metadata.
+
+#### 4.2.1 Bar Object
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `text` | string | REQUIRED | The lyric bar text |
+| `source` | BarSource | REQUIRED | Source information (track, album, year) |
+| `metrics` | BarMetrics | OPTIONAL | Quantitative metrics |
+| `semantics` | BarSemantics | OPTIONAL | Semantic analysis |
+| `language` | string | OPTIONAL | ISO 639-1 language code for this bar |
+
+#### 4.2.2 BarSource Object
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `track` | string | REQUIRED | Track/song title |
+| `album` | string | OPTIONAL | Album name |
+| `year` | integer | OPTIONAL | Release year (1-2200) |
+| `featuring` | string[] | OPTIONAL | Featured artists |
+| `timestamp` | string | OPTIONAL | MM:SS format |
+
+#### 4.2.3 BarMetrics Object
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `syllable_count` | integer | OPTIONAL | Number of syllables |
+| `word_count` | integer | OPTIONAL | Number of words |
+| `rhyme_density` | number | OPTIONAL | Rhyme density score (0.0-1.0) |
+
+#### 4.2.4 BarSemantics Object
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mood` | Mood | OPTIONAL | Mood classification |
+| `themes` | string[] | OPTIONAL | Thematic tags |
+| `techniques` | string[] | OPTIONAL | Lyrical techniques used |
+
+#### 4.2.5 Mood Enum Values
+
+- `aggressive`, `melancholic`, `triumphant`, `reflective`, `humorous`
+- `romantic`, `defiant`, `hopeful`, `dark`, `celebratory`
+
+---
+
+## 5. File Conventions
+
+### 5.1 File Extension
 
 WordGrain files SHOULD use the `.wg.json` extension:
 
@@ -209,7 +275,7 @@ kendrick-lamar.wg.json
 wu-tang-clan.wg.json
 ```
 
-### 4.2 Naming Conventions
+### 5.2 Naming Conventions
 
 | Pattern | Example | Use Case |
 |---------|---------|----------|
@@ -219,15 +285,15 @@ wu-tang-clan.wg.json
 
 Slugs SHOULD be lowercase, hyphen-separated ASCII.
 
-### 4.3 Encoding
+### 5.3 Encoding
 
 Files MUST be encoded as UTF-8 without BOM.
 
 ---
 
-## 5. Versioning
+## 6. Versioning
 
-### 5.1 Schema Version
+### 6.1 Schema Version
 
 The `$schema` field indicates the specification version:
 
@@ -235,7 +301,9 @@ The `$schema` field indicates the specification version:
 https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v{MAJOR}.{MINOR}.{PATCH}/wordgrain.schema.json
 ```
 
-### 5.2 Semantic Versioning Rules
+The `schema_version` field MUST contain the version string (e.g., `"0.2.0"`).
+
+### 6.2 Semantic Versioning Rules
 
 | Change Type | Version Bump | Example |
 |-------------|--------------|---------|
@@ -243,14 +311,14 @@ https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v{MAJOR}.{MIN
 | New optional fields | MINOR | v0.1.0 -> v0.2.0 |
 | Documentation/typo fixes | PATCH | v0.1.0 -> v0.1.1 |
 
-### 5.3 Compatibility
+### 6.3 Compatibility
 
 - Consumers SHOULD ignore unknown fields for forward compatibility
 - Producers MUST NOT remove required fields in minor versions
 
 ---
 
-## 6. MIME Type
+## 7. MIME Type
 
 Recommended MIME type: `application/vnd.wordgrain+json`
 
@@ -258,13 +326,14 @@ Until registered, use: `application/json`
 
 ---
 
-## 7. Examples
+## 8. Examples
 
-### 7.1 Minimal Valid Document
+### 8.1 Minimal Valid Document (Grains only)
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json",
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
   "meta": {
     "source": "manual",
     "artist": "Example Artist",
@@ -274,66 +343,114 @@ Until registered, use: `application/json`
 }
 ```
 
-### 7.2 Complete Example
+### 8.2 Bars Only Document
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
+  "meta": {
+    "source": "manual",
+    "artist": "KOHH",
+    "generated_at": "2026-03-06T00:00:00Z",
+    "language": "ja"
+  },
+  "bars": [
+    {
+      "text": "結局俺は俺 お前はお前",
+      "source": { "track": "貧乏なんて気にしない", "album": "MONEYFLOWER", "year": 2017 },
+      "semantics": { "mood": "defiant", "themes": ["identity"] }
+    }
+  ]
+}
+```
+
+### 8.3 Mixed Document (Grains + Bars)
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
+  "meta": {
+    "source": "manual",
+    "artist": "Kendrick Lamar",
+    "generated_at": "2026-03-06T00:00:00Z"
+  },
+  "grains": [
+    { "word": "hustle", "frequency": 47, "tfidf": 0.82 }
+  ],
+  "bars": [
+    {
+      "text": "I got hustle though, ambition flow inside my DNA",
+      "source": { "track": "DNA.", "album": "DAMN.", "year": 2017 },
+      "semantics": { "mood": "aggressive", "themes": ["ambition"] }
+    }
+  ]
+}
+```
+
+### 8.4 Complete Example
 
 See [examples/kendrick-lamar.wg.json](../examples/kendrick-lamar.wg.json) for a full-featured example.
 
 ---
 
-## 8. Validation
+## 9. Validation
 
-### 8.1 JSON Schema
+### 9.1 JSON Schema
 
 The official JSON Schema is available at:
 
-- Local: [schema/v0.1.0/wordgrain.schema.json](../schema/v0.1.0/wordgrain.schema.json)
-- Remote: `https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json`
+- Local: [schema/v0.2.0/wordgrain.schema.json](../schema/v0.2.0/wordgrain.schema.json)
+- Remote: `https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json`
 
-### 8.2 Validation Rules
+### 9.2 Validation Rules
 
 1. Document MUST be valid JSON
 2. Document MUST validate against the JSON Schema
-3. `generated_at` MUST be a valid ISO 8601 datetime
-4. `tfidf` and `sentiment_score` MUST be within specified ranges
+3. Document MUST contain at least one of `grains` or `bars`
+4. `generated_at` MUST be a valid ISO 8601 datetime
+5. `tfidf` and `sentiment_score` MUST be within specified ranges
 
-### 8.3 Validation Commands
+### 9.3 Validation Commands
 
 ```bash
 # Using ajv-cli
-npx ajv validate -s schema/v0.1.0/wordgrain.schema.json -d your-file.wg.json --spec=draft2020
+npx ajv validate -s schema/v0.2.0/wordgrain.schema.json -d your-file.wg.json --spec=draft2020
 
 # Using Python jsonschema
-python -m jsonschema -i your-file.wg.json schema/v0.1.0/wordgrain.schema.json
+python -m jsonschema -i your-file.wg.json schema/v0.2.0/wordgrain.schema.json
 ```
 
 ---
 
-## 9. Security Considerations
+## 10. Security Considerations
 
-### 9.1 Copyright
+### 10.1 Copyright
 
-- Context lines SHOULD be limited excerpts (fair use)
+- Context lines and bar text SHOULD be limited excerpts (fair use)
 - Full lyrics MUST NOT be stored
 - Attribution to original artists is RECOMMENDED
 
-### 9.2 Data Validation
+### 10.2 Data Validation
 
 - Consumers SHOULD validate input against schema
 - Untrusted sources SHOULD be sanitized
 
 ---
 
-## 10. Future Extensions
+## 11. Future Extensions
 
-### 10.1 Planned for v0.2.0
+### 11.1 Planned
 
 | Feature | Description |
 |---------|-------------|
+| `verse` content type | Structured verse-level analysis |
 | `embedding` | Word embedding vectors |
 | `phonetics` | IPA pronunciation, rhyme patterns |
 | `audio_link` | Reference to audio timestamps |
 
-### 10.2 Planned for v1.0.0
+### 11.2 Planned for v1.0.0
 
 | Feature | Description |
 |---------|-------------|
@@ -341,7 +458,7 @@ python -m jsonschema -i your-file.wg.json schema/v0.1.0/wordgrain.schema.json
 | Binary format | Efficient storage for embeddings |
 | Multi-language | Full i18n support |
 
-### 10.3 Extension Mechanism
+### 11.3 Extension Mechanism
 
 Custom fields can be added via the `extensions` object:
 
@@ -357,7 +474,7 @@ Custom fields can be added via the `extensions` object:
 
 ---
 
-## 11. References
+## 12. References
 
 - [RFC 2119](https://tools.ietf.org/html/rfc2119) - Key words
 - [JSON Schema](https://json-schema.org/) - Validation
@@ -371,3 +488,4 @@ Custom fields can be added via the `extensions` object:
 | Version | Date | Changes |
 |---------|------|---------|
 | v0.1.0 | 2026-02-08 | Initial draft |
+| v0.2.0 | 2026-03-06 | Unified document format: added `bars` section, `schema_version` field; `grains` and `bars` are both optional but at least one required |


### PR DESCRIPTION
## Summary

- Introduce v0.2.0 unified document format: a single `.wg.json` file can contain `grains` (vocabulary), `bars` (lyric analysis), or both
- Add `schema_version` field and `Bar`/`BarSource`/`BarMetrics`/`BarSemantics`/`Mood` definitions to schema
- Use `anyOf` constraint to require at least one of `grains` or `bars`
- Update RFC spec, TypeScript types, site components, examples, and README

## Test plan

- [x] AJV validation: grains-only, bars-only, mixed documents all pass
- [x] AJV validation: document with neither grains nor bars is rejected
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Verify site builds and deploys correctly
- [ ] Verify explorer/playground work with new examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)